### PR TITLE
SlevomatCodingStandard.Operators.DisallowEqualOperators: prevent risky fix

### DIFF
--- a/src/LaminasCodingStandard/ruleset.xml
+++ b/src/LaminasCodingStandard/ruleset.xml
@@ -644,7 +644,7 @@
     </rule>
     <!-- Loose comparison operators SHOULD NOT be used, use strict comparison
          operators instead. -->
-    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
+    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators" phpcs-only="true"/>
     <!-- The null coalesce operator MUST be used when possible. -->
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
     <!-- Assignment operators SHOULD be used when possible. -->

--- a/test/fixable/6.Operators.php
+++ b/test/fixable/6.Operators.php
@@ -84,6 +84,7 @@ class Operators
     {
         // Loose comparison operators SHOULD NOT be used, use strict comparison
         // operators instead.
+        // Fix that manually.
 
         $foo == 123;
         123 == $foo;

--- a/test/fixed/6.Operators.php
+++ b/test/fixed/6.Operators.php
@@ -83,11 +83,12 @@ class Operators
     {
         // Loose comparison operators SHOULD NOT be used, use strict comparison
         // operators instead.
+        // Fix that manually.
 
-        $foo === 123;
-        123 === $foo;
-        true !== 0.0;
-        false !== true;
+        $foo == 123;
+        123 == $foo;
+        true != 0.0;
+        false <> true;
     }
 
     public function testUseNullCoalesceOperator(): void


### PR DESCRIPTION
Propose disable automatic correction for https://github.com/laminas/laminas-coding-standard/issues/17 because they change code behavior.

Test remain updated to check issue found but automatic fix is disabled.

The only bug is: phpcs shows phpcbf can fix the issue

```
<?php

var_dump(1 != '1');
```

```
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 3 | ERROR | [x] Operator != is disallowed, use !== instead.
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```