### PR TITLE
Mention how to ignore a PHPCS violation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ $xmlPackage->send();
 // phpcs:enable
 ```
 
+Ignore a specific violation:
+```php
+$xmlPackage = new XMLPackage;
+$xmlPackage['error_code'] = get_default_error_code_value();
+// phpcs:ignore Generic.Commenting.Todo.Found
+// TODO: Add an error message here.
+$xmlPackage->send();
+```
+
 ## Development
 
 > **New rules or Sniffs may not be introduced in minor or bugfix releases and should always be based on the develop 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

Using `phpcs:disable` requires people to re-enable PHPCS or a sniff, which is a bit error-prone.
This just adds `phpcs:ignore` to the example list.
