### PR TITLE
QA fixes for documentation

### DIFF
--- a/docs/book/v1/intro.md
+++ b/docs/book/v1/intro.md
@@ -4,12 +4,12 @@ This component provides the coding standard ruleset for Laminas components.
 
 ## Installation
 
-1. Install the module via composer by running:
+1. Install the module via Composer by running:
    ```bash
    $ composer require --dev laminas/laminas-coding-standard
    ```
 
-2. Add composer scripts into your `composer.json`:
+2. Add Composer scripts into your `composer.json`:
    ```json
    "scripts": {
      "cs-check": "phpcs",

--- a/docs/book/v1/intro.md
+++ b/docs/book/v1/intro.md
@@ -1,4 +1,4 @@
-# laminas-coding-standard
+# Introduction
 
 ## Installation
 

--- a/docs/book/v1/intro.md
+++ b/docs/book/v1/intro.md
@@ -1,7 +1,5 @@
 # laminas-coding-standard
 
-This component provides the coding standard ruleset for Laminas components.
-
 ## Installation
 
 1. Install the module via Composer by running:

--- a/docs/book/v1/intro.md
+++ b/docs/book/v1/intro.md
@@ -5,13 +5,11 @@ This component provides the coding standard ruleset for Laminas components.
 ## Installation
 
 1. Install the module via composer by running:
-
    ```bash
    $ composer require --dev laminas/laminas-coding-standard
    ```
 
 2. Add composer scripts into your `composer.json`:
-
    ```json
    "scripts": {
      "cs-check": "phpcs",
@@ -20,7 +18,6 @@ This component provides the coding standard ruleset for Laminas components.
    ```
 
 3. Create file `phpcs.xml` on base path of your repository with content:
-
    ```xml
    <?xml version="1.0"?>
    <ruleset name="Laminas Coding Standard">
@@ -39,13 +36,11 @@ For a reference please see: https://github.com/squizlabs/PHP_CodeSniffer/wiki/An
 ## Usage
 
 * To run checks only:
-
   ```bash
   $ composer cs-check
   ```
 
 * To automatically fix many CS issues:
-
   ```bash
   $ composer cs-fix
   ```

--- a/docs/book/v2/intro.md
+++ b/docs/book/v2/intro.md
@@ -57,8 +57,8 @@ that's where this coding standard comes in: To have internal consistency in a co
    </ruleset>
    ```
 
-You can add or exclude some locations in that file.
-For a reference please see: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+You can add or exclude some locations in that file. For a reference please see
+the ["Annotated Ruleset" of PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset).
 
 ## Usage
 

--- a/docs/book/v2/intro.md
+++ b/docs/book/v2/intro.md
@@ -1,8 +1,10 @@
 # Introduction
 
-This specification extends and expands [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md), 
+**This specification extends and expands [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md), 
 the extended coding style guide and requires adherence to [PSR-1](https://www.php-fig.org/psr/psr-1), 
-the basic coding standard. These are minimal specifications and don't address all factors, including things like:
+the basic coding standard.**
+
+These are minimal specifications and don't address all factors, including things like:
 
 - whitespace around operators
 - alignment of array keys and operators

--- a/docs/book/v2/intro.md
+++ b/docs/book/v2/intro.md
@@ -121,7 +121,8 @@ $ composer global require --dev laminas/laminas-coding-standard:dev-<FORKED_BRAN
 $ phpcs -sp --standard=LaminasCodingStandard src test
 ```
 
-Make sure you remove the global installation after testing from your global composer.json file!!!
+**Make sure you remove the global installation after testing from your global
+`composer.json` file!**
 
 Documentation can be previewed locally by installing [MkDocs](https://www.mkdocs.org/#installation) and run 
 `mkdocs serve`. This will start a server where you can read the docs.

--- a/docs/book/v2/intro.md
+++ b/docs/book/v2/intro.md
@@ -20,13 +20,11 @@ that's where this coding standard comes in: To have internal consistency in a co
 ## Installation
 
 1. Install the module via composer by running:
-
    ```bash
    $ composer require --dev laminas/laminas-coding-standard
    ```
 
 2. Add composer scripts into your `composer.json`:
-
    ```json
    "scripts": {
      "cs-check": "phpcs",
@@ -35,7 +33,6 @@ that's where this coding standard comes in: To have internal consistency in a co
    ```
 
 3. Create file `phpcs.xml` on base path of your repository with this content:
-
    ```xml
    <?xml version="1.0"?>
    <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -66,13 +63,11 @@ For a reference please see: https://github.com/squizlabs/PHP_CodeSniffer/wiki/An
 ## Usage
 
 * To run checks only:
-
   ```bash
   $ composer cs-check
   ```
 
 * To automatically fix many CS issues:
-
   ```bash
   $ composer cs-fix
   ```

--- a/docs/book/v2/intro.md
+++ b/docs/book/v2/intro.md
@@ -19,12 +19,12 @@ that's where this coding standard comes in: To have internal consistency in a co
 
 ## Installation
 
-1. Install the module via composer by running:
+1. Install the module via Composer by running:
    ```bash
    $ composer require --dev laminas/laminas-coding-standard
    ```
 
-2. Add composer scripts into your `composer.json`:
+2. Add Composer scripts into your `composer.json`:
    ```json
    "scripts": {
      "cs-check": "phpcs",
@@ -110,7 +110,7 @@ $xmlPackage->send();
 > release, unless considered a bugfix for existing rules.
 
 If you want to test changes against Laminas components or your own projects, install your forked 
-laminas-coding-standard globally with composer:
+laminas-coding-standard globally with Composer:
 
 ```bash
 $ composer global config repositories.laminas-coding-standard vcs git@github.com:<FORK_NAMESPACE>/laminas-coding-standard.git

--- a/docs/book/v2/intro.md
+++ b/docs/book/v2/intro.md
@@ -1,7 +1,5 @@
 # laminas-coding-standard
 
-The coding standard ruleset for Laminas components.
-
 This specification extends and expands [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md), 
 the extended coding style guide and requires adherence to [PSR-1](https://www.php-fig.org/psr/psr-1), 
 the basic coding standard. These are minimal specifications and don't address all factors, including things like:

--- a/docs/book/v2/intro.md
+++ b/docs/book/v2/intro.md
@@ -74,8 +74,11 @@ For a reference please see: https://github.com/squizlabs/PHP_CodeSniffer/wiki/An
 
 ## Ignoring parts of a File
 
-> Note: Before PHP_CodeSniffer version 3.2.0, `// @codingStandardsIgnoreStart` and `// @codingStandardsIgnoreEnd` were
-> used. These are deprecated and will be removed in PHP_CodeSniffer version 4.0.
+> ### Deprecation
+>
+> Before PHP_CodeSniffer version 3.2.0, `// @codingStandardsIgnoreStart` and
+> `// @codingStandardsIgnoreEnd` were used. These are deprecated and will be
+> removed in PHP_CodeSniffer version 4.0.
 
 Disable parts of a file:
 ```php
@@ -98,8 +101,11 @@ $xmlPackage->send();
 
 ## Development
 
-> **New rules or Sniffs may not be introduced in minor or bugfix releases and should always be based on the develop 
-branch and queued for the next major release, unless considered a bugfix for existing rules.**
+> ### New Rules or Sniffs
+>
+> New rules or Sniffs may not be introduced in minor or bugfix releases and
+> should always be based on the develop branch and queued for the next major
+> release, unless considered a bugfix for existing rules.
 
 If you want to test changes against Laminas components or your own projects, install your forked 
 laminas-coding-standard globally with composer: 

--- a/docs/book/v2/intro.md
+++ b/docs/book/v2/intro.md
@@ -1,4 +1,4 @@
-# laminas-coding-standard
+# Introduction
 
 This specification extends and expands [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md), 
 the extended coding style guide and requires adherence to [PSR-1](https://www.php-fig.org/psr/psr-1), 

--- a/docs/book/v2/intro.md
+++ b/docs/book/v2/intro.md
@@ -81,6 +81,7 @@ For a reference please see: https://github.com/squizlabs/PHP_CodeSniffer/wiki/An
 > removed in PHP_CodeSniffer version 4.0.
 
 Disable parts of a file:
+
 ```php
 $xmlPackage = new XMLPackage;
 // phpcs:disable
@@ -90,6 +91,7 @@ $xmlPackage->send();
 ```
 
 Disable a specific rule:
+
 ```php
 // phpcs:disable Generic.Commenting.Todo.Found
 $xmlPackage = new XMLPackage;
@@ -108,7 +110,8 @@ $xmlPackage->send();
 > release, unless considered a bugfix for existing rules.
 
 If you want to test changes against Laminas components or your own projects, install your forked 
-laminas-coding-standard globally with composer: 
+laminas-coding-standard globally with composer:
+
 ```bash
 $ composer global config repositories.laminas-coding-standard vcs git@github.com:<FORK_NAMESPACE>/laminas-coding-standard.git
 $ composer global require --dev laminas/laminas-coding-standard:dev-<FORKED_BRANCH>
@@ -117,6 +120,7 @@ $ composer global require --dev laminas/laminas-coding-standard:dev-<FORKED_BRAN
 # Using `-s` prints the rules that triggered the errors so they can be reviewed easily. `-p` is for progress display.
 $ phpcs -sp --standard=LaminasCodingStandard src test
 ```
+
 Make sure you remove the global installation after testing from your global composer.json file!!!
 
 Documentation can be previewed locally by installing [MkDocs](https://www.mkdocs.org/#installation) and run 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| QA            | yes

### Description

The code bocks in lists needs an extra formatting which does not allow empty lines between text and code blocks. The problem is the underlying Markdown parser and the extensions.