### PR TITLE
Fix the link to the Annotated Ruleset wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ that's where this coding standard comes in: To have internal consistency in a co
    ```
 
 You can add or exclude some locations in that file.
-For a reference please see: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+For a reference please see: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset
 
 ## Usage
 

--- a/docs/book/v1/intro.md
+++ b/docs/book/v1/intro.md
@@ -29,7 +29,7 @@
    ```
 
 You can add or exclude some locations in that file.
-For a reference please see: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+For a reference please see: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset
 
 ## Usage
 


### PR DESCRIPTION
The “….xml” link redirects to the home page of PHP_CodeSniffer wiki.