### PR TITLE
add support dealerdirect/phpcodesniffer-composer-installer ^0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#34](https://github.com/laminas/laminas-coding-standard/pull/34) Added support for `dealerdirect/phpcodesniffer-composer-installer` and thus composer 2.0
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "^7.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "slevomat/coding-standard": "^6.2.0",
         "squizlabs/php_codesniffer": "^3.5.3",


### PR DESCRIPTION
Signed-off-by: Abdul Malik Ikhsan <samsonasik@gmail.com>

When using composer v2 in mezzio app, I got the following error:

```bash
Problem 1
    - dealerdirect/phpcodesniffer-composer-installer v0.6.2 requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
    - laminas/laminas-coding-standard 2.0.0 requires dealerdirect/phpcodesniffer-composer-installer ^0.6.2 -> satisfiable by dealerdirect/phpcodesniffer-composer-installer[v0.6.2].
    - Root composer.json requires laminas/laminas-coding-standard ^2.0.0 -> satisfiable by laminas/laminas-coding-standard[2.0.0].
```

Updated dealerdirect/phpcodesniffer-composer-installer to support ^0.7 based on @boesing suggestion.

|    Q          |   A
|-------------- | ------
| Documentation | yes/no
| Bugfix        | yes/no
| BC Break      | yes/no
| New Feature   | yes/no
| RFC           | yes/no
| QA            | yes/no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
