### PR TITLE
Remove contradicting rule for file header comment

### DIFF
--- a/src/LaminasCodingStandard/ruleset.xml
+++ b/src/LaminasCodingStandard/ruleset.xml
@@ -105,6 +105,7 @@
     <!-- The declare(strict_types=1) directive MUST be declared and be the
          first statement in a file. -->
     <rule ref="WebimpressCodingStandard.Files.DeclareStrictTypes">
+        <exclude name="WebimpressCodingStandard.Files.DeclareStrictTypes.BelowComment"/>
         <properties>
             <property name="containsTags" type="array">
                 <element value="@copyright"/>


### PR DESCRIPTION
This MR removes the contradicting rules for the file header comment.

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Fixes #35