### PR TITLE
fix: unused imports and generics

### DIFF
--- a/src/LaminasCodingStandard/ruleset.xml
+++ b/src/LaminasCodingStandard/ruleset.xml
@@ -264,13 +264,17 @@
     <!-- There MAY NOT be a space around a namespace separator. -->
     <rule ref="WebimpressCodingStandard.WhiteSpace.NamespaceSeparator"/>
     <!-- Import statements MUST be alphabetically sorted. -->
-    <rule ref="WebimpressCodingStandard.Namespaces.AlphabeticallySortedUses"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
     <!-- Functions and const keywords MUST be lowercase in import statements. -->
     <rule ref="WebimpressCodingStandard.Namespaces.ConstAndFunctionKeywords"/>
     <!-- Unused import statements MUST be removed.-->
-    <rule ref="WebimpressCodingStandard.Namespaces.UnusedUseStatement"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
     <!-- Superfluous leading backslash in import statements MUST be removed. -->
-    <rule ref="WebimpressCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <!-- Fancy group import statements MUST NOT be used. -->
     <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
     <!-- Each import statement MUST be on its own line. -->
@@ -280,13 +284,23 @@
     <rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
     <!-- Import statements aliases for classes, traits, functions and constants
          MUST be useful. -->
-    <rule ref="WebimpressCodingStandard.Namespaces.RedundantAlias"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
     <!-- Classes, traits, interfaces, constants and functions MUST be imported. -->
-    <rule ref="WebimpressCodingStandard.PHP.DisallowFqn"/>
-    <!-- Internal functions MUST be imported. -->
-    <rule ref="WebimpressCodingStandard.PHP.ImportInternalFunction"/>
-    <!-- Internal constants MUST be imported. -->
-    <rule ref="WebimpressCodingStandard.PHP.ImportInternalConstant"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly">
+        <properties>
+            <property name="allowFullyQualifiedGlobalClasses" value="false"/>
+            <!-- Internal functions MUST be imported. -->
+            <property name="allowFallbackGlobalFunctions" value="false"/>
+            <property name="allowFullyQualifiedGlobalFunctions" value="false"/>
+            <!-- Internal constants MUST be imported. -->
+            <property name="allowFallbackGlobalConstants" value="false"/>
+            <property name="allowFullyQualifiedGlobalConstants" value="false"/>
+            <property name="allowFullyQualifiedNameForCollidingClasses" value="true"/>
+            <property name="allowFullyQualifiedNameForCollidingConstants" value="true"/>
+            <property name="allowFullyQualifiedNameForCollidingFunctions" value="true"/>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
 
     <!-- 4. Classes, Properties, and Methods -->
 
@@ -787,11 +801,14 @@
 
     <!-- DocBlocks and comments SHOULD NOT be used for already typehinted arguments,
          except arrays. -->
-    <rule ref="WebimpressCodingStandard.Functions.Param"/>
-    <rule ref="WebimpressCodingStandard.Functions.ReturnType"/>
-    <rule ref="WebimpressCodingStandard.Commenting.TagWithType">
-        <exclude name="WebimpressCodingStandard.Commenting.TagWithType.InvalidOrder"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+        <properties>
+            <property name="enableNativeTypeHint" value="false"/>
+        </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
 
     <!-- The asterisks in a DocBlock should align, and there should be one
          space between the asterisk and tag. -->

--- a/test/expected-report.txt
+++ b/test/expected-report.txt
@@ -7,22 +7,22 @@ test/fixable/2.1.BasicCodingStandard.php              48      1
 test/fixable/2.2.Files.php                            6       0
 test/fixable/2.3.Lines.php                            35      0
 test/fixable/2.4.IndentingAndSpacing.php              46      0
-test/fixable/2.5.KeywordsAndTypes.php                 13      0
+test/fixable/2.5.KeywordsAndTypes.php                 8       0
 test/fixable/2.6.Variables.php                        3       0
 test/fixable/2.7.Arrays.php                           9       0
-test/fixable/3.DeclareNamespaceAndImport.php          11      0
+test/fixable/3.DeclareNamespaceAndImport.php          12      0
 test/fixable/4.1.ExtendsAndImplements.php             5       0
-test/fixable/4.2.UsingTraits.php                      4       0
-test/fixable/4.3.PropertiesAndConstants.php           5       0
-test/fixable/4.4.MethodsAndFunctions.php              26      0
+test/fixable/4.2.UsingTraits.php                      5       0
+test/fixable/4.3.PropertiesAndConstants.php           7       0
+test/fixable/4.4.MethodsAndFunctions.php              27      0
 test/fixable/4.5.MethodAndFunctionArguments.php       66      0
-test/fixable/4.6.AbstractFinalAndStatic.php           4       0
+test/fixable/4.6.AbstractFinalAndStatic.php           5       0
 test/fixable/4.7.MethodAndFunctionCalls.php           11      0
-test/fixable/4.ClassesPropertiesAndMethods.php        32      0
-test/fixable/5.1.IfElseifElse.php                     15      1
+test/fixable/4.ClassesPropertiesAndMethods.php        34      0
+test/fixable/5.1.IfElseifElse.php                     13      1
 test/fixable/5.2.SwitchCase.php                       11      0
 test/fixable/5.3.WhileAndDoWhile.php                  12      0
-test/fixable/5.4.ForStructure.php                     7       0
+test/fixable/5.4.ForStructure.php                     5       0
 test/fixable/5.5.ForEachStructure.php                 10      0
 test/fixable/5.6.TryCatchFinally.php                  9       0
 test/fixable/5.ControlStructures.php                  4       0
@@ -30,13 +30,14 @@ test/fixable/6.1.UnaryOperators.php                   6       0
 test/fixable/6.2.BinaryOperators.php                  35      0
 test/fixable/6.3.TernaryOperators.php                 13      0
 test/fixable/6.Operators.php                          97      0
-test/fixable/7.Closures.php                           2       0
+test/fixable/7.Closures.php                           4       0
 test/fixable/8.AnonymousClasses.php                   1       0
-test/fixable/9.CommentingAndDocBlocks.php             21      0
+test/fixable/9.CommentingAndDocBlocks.php             17      0
+test/fixable/9.GenericTypeHintSyntax.php              4       0
 ----------------------------------------------------------------------
-A TOTAL OF 567 ERRORS AND 2 WARNINGS WERE FOUND IN 30 FILES
+A TOTAL OF 568 ERRORS AND 2 WARNINGS WERE FOUND IN 31 FILES
 ----------------------------------------------------------------------
-PHPCBF CAN FIX 487 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
+PHPCBF CAN FIX 484 OF THESE SNIFF VIOLATIONS AUTOMATICALLY
 ----------------------------------------------------------------------
 
 

--- a/test/fixable/2.3.Lines.php
+++ b/test/fixable/2.3.Lines.php
@@ -60,13 +60,13 @@ class Lines
         // There MAY NOT be any blank line after opening braces and before
         // closing braces.
 
-        $noBlankLine = function () use ($noBlankLine) {
+        $noBlankLine = function () use ($noBlankLine): void {
 
             $noBlankLine = 1;
 
         };
 
-        $closure = function () {
+        $closure = function (): void {
 
             $noBlankLine = 1;
 

--- a/test/fixable/2.7.Arrays.php
+++ b/test/fixable/2.7.Arrays.php
@@ -27,7 +27,7 @@ class Arrays
         ];
 
         $array2 = [
-            'one'    => function () {
+            'one'    => function (): void {
                 $foo    = [1, 2, 3];
                 $barBar = [
                     1,

--- a/test/fixable/4.1.ExtendsAndImplements.php
+++ b/test/fixable/4.1.ExtendsAndImplements.php
@@ -16,7 +16,7 @@ class ExtendsAndImplements
     ArrayAccess,
     Countable,
     Serializable {
-    public function testClassDeclaration()
+    public function testClassDeclaration(): void
     {
         // The extends and implements keywords MUST be declared on the same line
         // as the class name.

--- a/test/fixable/4.4.MethodsAndFunctions.php
+++ b/test/fixable/4.4.MethodsAndFunctions.php
@@ -19,7 +19,7 @@ class MethodsAndFunctions
         // NOT be a space after the opening parenthesis, and there MUST NOT be a
         // space before the closing parenthesis.
 
-        function fooBar ( $arg1, &$arg2, $arg3 = [] ) {
+        function fooBar ( $arg1, &$arg2, $arg3 = [] ): void {
             // function body
         }
 
@@ -27,7 +27,7 @@ class MethodsAndFunctions
 
 
 
-    public function testOneSingleLineBetweenMethods()
+    public function testOneSingleLineBetweenMethods(): void
     {
         // There MUST be a single empty line between methods in a class.
     }

--- a/test/fixable/4.5.MethodAndFunctionArguments.php
+++ b/test/fixable/4.5.MethodAndFunctionArguments.php
@@ -74,7 +74,7 @@ class MethodAndFunctionArguments
         // When combining both the reference operator and the variadic three dot
         // operator, there MUST NOT be any space between the two of them.
 
-        function method($a, $b, ... $c) {
+        function method($a, $b, ... $c): void {
             if ($a < $b) {
                 method(... func_get_args());
             }

--- a/test/fixable/6.Operators.php
+++ b/test/fixable/6.Operators.php
@@ -65,7 +65,7 @@ class Operators
         $result*=4;
     }
 
-    public function testObjectOperatorSpacing()
+    public function testObjectOperatorSpacing(): void
     {
         // There MAY NOT be any white space around the object operator unless
         // multilines are used.

--- a/test/fixable/7.Closures.php
+++ b/test/fixable/7.Closures.php
@@ -37,11 +37,11 @@ class Closures
         // MUST follow the use list closing parentheses with no spaces between
         // the two characters.
 
-        $closureWithArgs = function ($arg1, $arg2) {
+        $closureWithArgs = function ($arg1, $arg2): void {
             echo "$arg1, $arg2";
         };
 
-        $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
+        $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2): void {
             echo "$arg1, $arg2, $var1, $var2";
         };
 

--- a/test/fixable/9.GenericTypeHintSyntax.php
+++ b/test/fixable/9.GenericTypeHintSyntax.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-coding-standard for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-coding-standard/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-coding-standard/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+use IteratorAggregate;
+
+class GenericTypeHintSyntax
+{
+    /** @psalm-var IteratorAggregate */
+    private $config;
+
+    /** @var IteratorAggregate<string,string> */
+    private $bar;
+
+    /**
+     * @param IteratorAggregate<string,string> $bar
+     */
+    public function __construct(ArrayObject $bar)
+    {
+        $this->bar = $bar;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function doSomethingWithArray(array $config): void
+    {
+        $this->config = $config;
+    }
+}

--- a/test/fixed/2.3.Lines.php
+++ b/test/fixed/2.3.Lines.php
@@ -50,11 +50,11 @@ class Lines
         // There MAY NOT be any blank line after opening braces and before
         // closing braces.
 
-        $noBlankLine = function () use ($noBlankLine) {
+        $noBlankLine = function () use ($noBlankLine): void {
             $noBlankLine = 1;
         };
 
-        $closure = function () {
+        $closure = function (): void {
             $noBlankLine = 1;
         };
 

--- a/test/fixed/2.7.Arrays.php
+++ b/test/fixed/2.7.Arrays.php
@@ -27,7 +27,7 @@ class Arrays
         ];
 
         $array2 = [
-            'one'    => function () {
+            'one'    => function (): void {
                 $foo    = [1, 2, 3];
                 $barBar = [
                     1,

--- a/test/fixed/4.1.ExtendsAndImplements.php
+++ b/test/fixed/4.1.ExtendsAndImplements.php
@@ -14,7 +14,7 @@ class ExtendsAndImplements extends ParentClass implements
     Countable,
     Serializable
 {
-    public function testClassDeclaration()
+    public function testClassDeclaration(): void
     {
         // The extends and implements keywords MUST be declared on the same line
         // as the class name.

--- a/test/fixed/4.4.MethodsAndFunctions.php
+++ b/test/fixed/4.4.MethodsAndFunctions.php
@@ -6,7 +6,7 @@ namespace LaminasCodingStandardTest\fixed;
 
 class MethodsAndFunctions
 {
-    public function testMethodsAndFunctions($arg1, &$arg2, $arg3 = [])
+    public function testMethodsAndFunctions($arg1, &$arg2, $arg3 = []): void
     {
         // Visibility MUST be declared on all methods.
         //
@@ -20,13 +20,13 @@ class MethodsAndFunctions
         // NOT be a space after the opening parenthesis, and there MUST NOT be a
         // space before the closing parenthesis.
 
-        function fooBar($arg1, &$arg2, $arg3 = [])
+        function fooBar($arg1, &$arg2, $arg3 = []): void
         {
             // function body
         }
     }
 
-    public function testOneSingleLineBetweenMethods()
+    public function testOneSingleLineBetweenMethods(): void
     {
         // There MUST be a single empty line between methods in a class.
     }

--- a/test/fixed/4.5.MethodAndFunctionArguments.php
+++ b/test/fixed/4.5.MethodAndFunctionArguments.php
@@ -74,7 +74,7 @@ class MethodAndFunctionArguments
         // When combining both the reference operator and the variadic three dot
         // operator, there MUST NOT be any space between the two of them.
 
-        function method($a, $b, ...$c)
+        function method($a, $b, ...$c): void
         {
             if ($a < $b) {
                 method(...func_get_args());

--- a/test/fixed/6.Operators.php
+++ b/test/fixed/6.Operators.php
@@ -65,7 +65,7 @@ class Operators
         $result *= 4;
     }
 
-    public function testObjectOperatorSpacing()
+    public function testObjectOperatorSpacing(): void
     {
         // There MAY NOT be any white space around the object operator unless
         // multilines are used.

--- a/test/fixed/7.Closures.php
+++ b/test/fixed/7.Closures.php
@@ -37,11 +37,11 @@ class Closures
         // MUST follow the use list closing parentheses with no spaces between
         // the two characters.
 
-        $closureWithArgs = function ($arg1, $arg2) {
+        $closureWithArgs = function ($arg1, $arg2): void {
             echo "$arg1, $arg2";
         };
 
-        $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
+        $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2): void {
             echo "$arg1, $arg2, $var1, $var2";
         };
 
@@ -65,7 +65,7 @@ class Closures
         // Inherited variables passed via `use` MUST be used in closures.
 
         $message = 'world';
-        $example = function ($arg) use ($message) {
+        $example = function ($arg) use ($message): void {
             echo "$arg $message";
         };
         $example('hello');

--- a/test/fixed/9.GenericTypeHintSyntax.php
+++ b/test/fixed/9.GenericTypeHintSyntax.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-coding-standard for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-coding-standard/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-coding-standard/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+use IteratorAggregate;
+
+class GenericTypeHintSyntax
+{
+    /** @psalm-var IteratorAggregate */
+    private $config;
+
+    /** @var IteratorAggregate<string,string> */
+    private $bar;
+
+    /**
+     * @param IteratorAggregate<string,string> $bar
+     */
+    public function __construct(ArrayObject $bar)
+    {
+        $this->bar = $bar;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function doSomethingWithArray(array $config): void
+    {
+        $this->config = $config;
+    }
+}


### PR DESCRIPTION
Adds support for psalm-var and genercis in docblock:

- @psalm-var IteratorAggregate
- @var IteratorAggregate<string,string>
- @param IteratorAggregate<string,string> $config

As a positive side effect, this also detects missing native return types like `void` and can fix these automatically. 
Propert type hint is switched of as PHP 7.3 must still be supported.

Fixes #23
