### PR TITLE
Remove laminas-zendframework-bridge.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "require": {
         "php": "^7.3 || ~8.0.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-        "laminas/laminas-zendframework-bridge": "^1.0",
         "slevomat/coding-standard": "^6.4.1",
         "squizlabs/php_codesniffer": "^3.5.8",
         "webimpress/coding-standard": "^1.1.6"


### PR DESCRIPTION
laminas-coding-standard is used by other laminas projects. Although it's mostly a dev dependency, it's still probably a good idea to remove the zendframework bridge, to avoid having more complicated autoloading than needed.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | yes/no

### Description

Tell us about why this change is necessary:

Although it's mostly a dev dependency, it's still probably a good idea to remove the zendframework bridge, to avoid having more complicated autoloading than needed.

See https://github.com/laminas/laminas-escaper/issues/11#issuecomment-826844368

- Are you fixing a BC Break?
  - How do you reproduce it?
composer update.
  
  - What was the previous behavior?
  
Has the zend bridge.
  
  - What is the current behavior?

Not to have the bridge.





