### PR TITLE
Normalize composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,22 @@
 {
     "name": "laminas/laminas-coding-standard",
-    "description": "Laminas Coding Standard",
     "type": "phpcodesniffer-standard",
-    "license": "BSD-3-Clause",
+    "description": "Laminas Coding Standard",
     "keywords": [
         "laminas",
         "coding standard"
     ],
     "homepage": "https://laminas.dev",
-    "support": {
-        "docs": "https://docs.laminas.dev/laminas-coding-standard/",
-        "issues": "https://github.com/laminas/laminas-coding-standard/issues",
-        "source": "https://github.com/laminas/laminas-coding-standard",
-        "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
-        "chat": "https://laminas.dev/chat",
-        "forum": "https://discourse.laminas.dev"
-    },
-    "config": {
-        "sort-packages": true
-    },
+    "license": "BSD-3-Clause",
     "require": {
         "php": "^7.3 || ~8.0.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
         "slevomat/coding-standard": "^6.4.1",
         "squizlabs/php_codesniffer": "^3.5.8",
         "webimpress/coding-standard": "^1.1.6"
+    },
+    "config": {
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {
@@ -43,8 +35,16 @@
             "@test-diff"
         ],
         "create-report": "phpcs $(find test/fixable/* | sort) --report=summary --report-file=test/expected-report.txt",
-        "test-prepare": "rm -rf test/fix/; cp -R test/fixable/ test/fix/;",
+        "test-diff": "diff test/fix test/fixed",
         "test-fix": "phpcbf test/fix > /dev/null || true",
-        "test-diff": "diff test/fix test/fixed"
+        "test-prepare": "rm -rf test/fix/; cp -R test/fixable/ test/fix/;"
+    },
+    "support": {
+        "issues": "https://github.com/laminas/laminas-coding-standard/issues",
+        "forum": "https://discourse.laminas.dev",
+        "chat": "https://laminas.dev/chat",
+        "source": "https://github.com/laminas/laminas-coding-standard",
+        "docs": "https://docs.laminas.dev/laminas-coding-standard/",
+        "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom"
     }
 }


### PR DESCRIPTION
**[QA]**
* Normalize `composer.json` and/or update `composer.lock`
    - Restructure `composer.json` according to the underlying [JSON schema](https://getcomposer.org/schema.json).
    - Prevent inconsistencies between all (200+) repositories across all 3 GitHub organizations (`laminas`, `mezzio`, and `laminas-api-tools`).