### PR TITLE
Exclude declare strict types below comment

### DIFF
--- a/src/LaminasCodingStandard/ruleset.xml
+++ b/src/LaminasCodingStandard/ruleset.xml
@@ -104,7 +104,9 @@
 
     <!-- The declare(strict_types=1) directive MUST be declared and be the
          first statement in a file. -->
-    <rule ref="WebimpressCodingStandard.Files.DeclareStrictTypes"/>
+    <rule ref="WebimpressCodingStandard.Files.DeclareStrictTypes">
+        <exclude name="WebimpressCodingStandard.Files.DeclareStrictTypes.BelowComment"/>
+    </rule>
 
     <!-- 2.3 Lines -->
 


### PR DESCRIPTION
This PR should fix the bug I re-introduced https://github.com/laminas/laminas-coding-standard/commit/8eb2a842f9a70f4bca1546b6614a2d27afcd9bb6 that had been fixed https://github.com/laminas/laminas-coding-standard/issues/35#issuecomment-841993531