### PR TITLE
feat: upgrade to slevomat/coding-standard 7 with enhanced PHP 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 The coding standard ruleset for Laminas components.
 
-This specification extends and expands [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md), 
-the extended coding style guide and requires adherence to [PSR-1](https://www.php-fig.org/psr/psr-1), 
+This specification extends and expands [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md),
+the extended coding style guide and requires adherence to [PSR-1](https://www.php-fig.org/psr/psr-1),
 the basic coding standard. These are minimal specifications and don't address all factors, including things like:
 
 - whitespace around operators
@@ -15,8 +15,8 @@ the basic coding standard. These are minimal specifications and don't address al
 - what and what not to import, and how
 - etc.
 
-Contributors have different coding styles and so do the maintainers. During code reviews there are regularly 
-discussions about spaces and alignments, where and when was said that a function needs to be imported. And 
+Contributors have different coding styles and so do the maintainers. During code reviews there are regularly
+discussions about spaces and alignments, where and when was said that a function needs to be imported. And
 that's where this coding standard comes in: To have internal consistency in a component and between components.
 
 ## Installation
@@ -24,7 +24,7 @@ that's where this coding standard comes in: To have internal consistency in a co
 1. Install the module via composer by running:
 
    ```bash
-   $ composer require --dev laminas/laminas-coding-standard
+   composer require --dev laminas/laminas-coding-standard
    ```
 
 2. Add composer scripts into your `composer.json`:
@@ -42,21 +42,21 @@ that's where this coding standard comes in: To have internal consistency in a co
    <?xml version="1.0"?>
    <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
-   
+
        <arg name="basepath" value="."/>
        <arg name="cache" value=".phpcs-cache"/>
        <arg name="colors"/>
        <arg name="extensions" value="php"/>
        <arg name="parallel" value="80"/>
-       
+
        <!-- Show progress -->
        <arg value="p"/>
-   
+
        <!-- Paths to check -->
        <file>config</file>
        <file>src</file>
        <file>test</file>
-   
+
        <!-- Include all rules from the Laminas Coding Standard -->
        <rule ref="LaminasCodingStandard"/>
    </ruleset>
@@ -67,16 +67,16 @@ For a reference please see: https://github.com/squizlabs/PHP_CodeSniffer/wiki/An
 
 ## Usage
 
-* To run checks only:
+- To run checks only:
 
   ```bash
-  $ composer cs-check
+  composer cs-check
   ```
 
-* To automatically fix many CS issues:
+- To automatically fix many CS issues:
 
   ```bash
-  $ composer cs-fix
+  composer cs-fix
   ```
 
 ## Ignoring parts of a File
@@ -85,6 +85,7 @@ For a reference please see: https://github.com/squizlabs/PHP_CodeSniffer/wiki/An
 > used. These are deprecated and will be removed in PHP_CodeSniffer version 4.0.
 
 Disable parts of a file:
+
 ```php
 $xmlPackage = new XMLPackage;
 // phpcs:disable
@@ -94,6 +95,7 @@ $xmlPackage->send();
 ```
 
 Disable a specific rule:
+
 ```php
 // phpcs:disable Generic.Commenting.Todo.Found
 $xmlPackage = new XMLPackage;
@@ -104,6 +106,7 @@ $xmlPackage->send();
 ```
 
 Ignore a specific violation:
+
 ```php
 $xmlPackage = new XMLPackage;
 $xmlPackage['error_code'] = get_default_error_code_value();
@@ -114,11 +117,12 @@ $xmlPackage->send();
 
 ## Development
 
-> **New rules or Sniffs may not be introduced in minor or bugfix releases and should always be based on the develop 
+> **New rules or Sniffs may not be introduced in minor or bugfix releases and should always be based on the develop
 branch and queued for the next major release, unless considered a bugfix for existing rules.**
 
-If you want to test changes against Laminas components or your own projects, install your forked 
-laminas-coding-standard globally with composer: 
+If you want to test changes against Laminas components or your own projects, install your forked
+laminas-coding-standard globally with composer:
+
 ```bash
 $ composer global config repositories.laminas-coding-standard vcs git@github.com:<FORK_NAMESPACE>/laminas-coding-standard.git
 $ composer global require --dev laminas/laminas-coding-standard:dev-<FORKED_BRANCH>
@@ -127,9 +131,10 @@ $ composer global require --dev laminas/laminas-coding-standard:dev-<FORKED_BRAN
 # Using `-s` prints the rules that triggered the errors so they can be reviewed easily. `-p` is for progress display.
 $ phpcs -sp --standard=LaminasCodingStandard src test
 ```
+
 Make sure you remove the global installation after testing from your global composer.json file!!!
 
-Documentation can be previewed locally by installing [MkDocs](https://www.mkdocs.org/#installation) and run 
+Documentation can be previewed locally by installing [MkDocs](https://www.mkdocs.org/#installation) and run
 `mkdocs serve`. This will start a server where you can read the docs.
 
 ## Reference

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
     "homepage": "https://laminas.dev",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.3 || ~8.0.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-        "slevomat/coding-standard": "^6.4.1",
-        "squizlabs/php_codesniffer": "^3.5.8",
-        "webimpress/coding-standard": "^1.1.6"
+        "php": "^7.3 || ^8.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+        "slevomat/coding-standard": "^7.0",
+        "squizlabs/php_codesniffer": "^3.6",
+        "webimpress/coding-standard": "^1.2"
     },
     "config": {
         "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7c5b8a82482b2c8ff8244fadeaa91c6",
+    "content-hash": "17342f59ab8e3ddb2b1c6e03e913dbf2",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -78,37 +78,34 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "0.4.9",
+            "version": "0.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
+                "reference": "e352d065af1ae9b41c12d1dfd309e90f7b1f55c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
-                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/e352d065af1ae9b41c12d1dfd309e90f7b1f55c9",
+                "reference": "e352d065af1ae9b41c12d1dfd309e90f7b1f55c9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "consistence/coding-standard": "^3.5",
-                "ergebnis/composer-normalize": "^2.0.2",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
-                "phing/phing": "^2.16.0",
+                "phing/phing": "^2.16.3",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.26",
-                "phpstan/phpstan-strict-rules": "^0.12",
-                "phpunit/phpunit": "^6.3",
-                "slevomat/coding-standard": "^4.7.2",
-                "symfony/process": "^4.0"
+                "phpstan/phpstan": "^0.12.60",
+                "phpstan/phpstan-strict-rules": "^0.12.5",
+                "phpunit/phpunit": "^7.5.20",
+                "symfony/process": "^5.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.4-dev"
+                    "dev-master": "0.5-dev"
                 }
             },
             "autoload": {
@@ -125,38 +122,38 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/0.5.4"
             },
-            "time": "2020-08-03T20:32:43+00:00"
+            "time": "2021-04-03T14:46:19+00:00"
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "6.4.1",
+            "version": "7.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
+                "reference": "48141737f9e5ed701ef8bcea2027e701b50bd932"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
-                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/48141737f9e5ed701ef8bcea2027e701b50bd932",
+                "reference": "48141737f9e5ed701ef8bcea2027e701b50bd932",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
                 "php": "^7.1 || ^8.0",
-                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
-                "squizlabs/php_codesniffer": "^3.5.6"
+                "phpstan/phpdoc-parser": "0.5.1 - 0.5.4",
+                "squizlabs/php_codesniffer": "^3.6.0"
             },
             "require-dev": {
-                "phing/phing": "2.16.3",
-                "php-parallel-lint/php-parallel-lint": "1.2.0",
-                "phpstan/phpstan": "0.12.48",
-                "phpstan/phpstan-deprecation-rules": "0.12.5",
-                "phpstan/phpstan-phpunit": "0.12.16",
-                "phpstan/phpstan-strict-rules": "0.12.5",
-                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
+                "phing/phing": "2.16.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.0",
+                "phpstan/phpstan": "0.12.86",
+                "phpstan/phpstan-deprecation-rules": "0.12.6",
+                "phpstan/phpstan-phpunit": "0.12.18",
+                "phpstan/phpstan-strict-rules": "0.12.9",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.5.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -176,7 +173,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/7.0.8"
             },
             "funding": [
                 {
@@ -188,7 +185,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-05T12:39:37+00:00"
+            "time": "2021-05-10T08:51:20+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -309,7 +306,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.3 || ^8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17342f59ab8e3ddb2b1c6e03e913dbf2",
+    "content-hash": "872b1030ee206aa2abda3d5ef7e8676f",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/src/LaminasCodingStandard/ruleset.xml
+++ b/src/LaminasCodingStandard/ruleset.xml
@@ -104,10 +104,6 @@
 
     <!-- The declare(strict_types=1) directive MUST be declared and be the
          first statement in a file. -->
-<<<<<<< HEAD
-    <rule ref="WebimpressCodingStandard.Files.DeclareStrictTypes">
-        <exclude name="WebimpressCodingStandard.Files.DeclareStrictTypes.BelowComment"/>
-=======
      <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
             <property name="declareOnFirstLine" value="false"/>
@@ -115,7 +111,6 @@
             <property name="spacesCountAroundEqualsSign" value="0"/>
             <property name="linesCountAfterDeclare" value="1"/>
         </properties>
->>>>>>> 28aaa6c (feat: update to slevomat/coding-standard 7 for improved PHP 8 suport)
     </rule>
 
     <!-- 2.3 Lines -->

--- a/src/LaminasCodingStandard/ruleset.xml
+++ b/src/LaminasCodingStandard/ruleset.xml
@@ -104,8 +104,18 @@
 
     <!-- The declare(strict_types=1) directive MUST be declared and be the
          first statement in a file. -->
+<<<<<<< HEAD
     <rule ref="WebimpressCodingStandard.Files.DeclareStrictTypes">
         <exclude name="WebimpressCodingStandard.Files.DeclareStrictTypes.BelowComment"/>
+=======
+     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="declareOnFirstLine" value="false"/>
+            <property name="linesCountBeforeDeclare" value="1"/>
+            <property name="spacesCountAroundEqualsSign" value="0"/>
+            <property name="linesCountAfterDeclare" value="1"/>
+        </properties>
+>>>>>>> 28aaa6c (feat: update to slevomat/coding-standard 7 for improved PHP 8 suport)
     </rule>
 
     <!-- 2.3 Lines -->

--- a/src/LaminasCodingStandard/ruleset.xml
+++ b/src/LaminasCodingStandard/ruleset.xml
@@ -334,8 +334,6 @@
     <rule ref="WebimpressCodingStandard.Formatting.StringClassReference"/>
     <!-- There MAY NOT be any whitespace around the double colon operator. -->
     <rule ref="WebimpressCodingStandard.Formatting.DoubleColon"/>
-    <!-- All private methods, constants and properties MUST be used. -->
-    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
 
     <!-- 4.1 Extends and Implements -->
 

--- a/test/fixable/4.ClassesPropertiesAndMethods.php
+++ b/test/fixable/4.ClassesPropertiesAndMethods.php
@@ -110,9 +110,4 @@ class ClassesPropertiesAndMethods extends AbstractFoo implements FooInterface
             ::
             createFromFormat('Y-m-d', '2016-01-01');
     }
-
-    public function testUnusedPrivateMethods(): void
-    {
-        // All private methods, constants and properties MUST be used.
-    }
 }

--- a/test/fixable/9.CommentingAndDocBlocks.php
+++ b/test/fixable/9.CommentingAndDocBlocks.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * This is a file level summary.
+ *
+ * This is a file level Description.
+ */
+
 declare(strict_types=1);
 
 namespace LaminasCodingStandardTest\fixed;

--- a/test/fixed/4.ClassesPropertiesAndMethods.php
+++ b/test/fixed/4.ClassesPropertiesAndMethods.php
@@ -107,9 +107,4 @@ class ClassesPropertiesAndMethods extends AbstractFoo implements FooInterface
 
         DateTime::createFromFormat('Y-m-d', '2016-01-01');
     }
-
-    public function testUnusedPrivateMethods(): void
-    {
-        // All private methods, constants and properties MUST be used.
-    }
 }

--- a/test/fixed/9.CommentingAndDocBlocks.php
+++ b/test/fixed/9.CommentingAndDocBlocks.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * This is a file level summary.
+ *
+ * This is a file level Description.
+ */
+
 declare(strict_types=1);
 
 namespace LaminasCodingStandardTest\fixed;


### PR DESCRIPTION
This PR updates the following dependencies:

```
"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
"slevomat/coding-standard": "^7.0",
"squizlabs/php_codesniffer": "^3.6",
"webimpress/coding-standard": "^1.2"
```

Mainly it contains an update to slevomat/coding-standard 7, which contains improvements for PHP 8 support.