### PR TITLE
Composer 2.2.0 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,10 @@
         "webimpress/coding-standard": "^1.2"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         "webimpress/coding-standard": "^1.2"
     },
     "config": {
-        "sort-packages": true,
         "allow-plugins": {
-	    "dealerdirect/phpcodesniffer-composer-installer": true
-	}
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "sort-packages": true
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
+	    "dealerdirect/phpcodesniffer-composer-installer": true
+	}
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This package uses `"dealerdirect/phpcodesniffer-composer-installer"`. With Composer Version `2.2.0` you have to add that plugin to `allow-plugins` section.

> Added [allow-plugins](https://getcomposer.org/doc/06-config.md#allow-plugins) config value to enhance security against runtime execution, this will prompt you the first time you use a plugin and may hang pipelines if they aren't using --no-interaction (-n) as they should