### PR TITLE
Normalize continuous integration configuration

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -5,7 +5,7 @@
             "job": {
                 "php": "*",
                 "command": "composer check",
-                "dependencies": ["lowest", "latest"]
+                "dependencies": "*"
             }
         },
         {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,10 @@
         "webimpress/coding-standard": "^1.2"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/test/fixable/2.3.Lines.php
+++ b/test/fixable/2.3.Lines.php
@@ -20,10 +20,12 @@ class Lines
 
     public function testTrailingWhitespace(): void
     {
-        // There MUST NOT be trailing whitespace at the end of lines.
-        //
-        // Blank lines MAY be added to improve readability and to indicate
-        // related blocks of code except where explicitly forbidden.
+        /**
+         * There MUST NOT be trailing whitespace at the end of lines.
+         *
+         * Blank lines MAY be added to improve readability and to indicate
+         * related blocks of code except where explicitly forbidden.
+         */
 
         $foo = 'bar';
     }

--- a/test/fixed/2.3.Lines.php
+++ b/test/fixed/2.3.Lines.php
@@ -19,10 +19,12 @@ class Lines
 
     public function testTrailingWhitespace(): void
     {
-        // There MUST NOT be trailing whitespace at the end of lines.
-        //
-        // Blank lines MAY be added to improve readability and to indicate
-        // related blocks of code except where explicitly forbidden.
+        /**
+         * There MUST NOT be trailing whitespace at the end of lines.
+         *
+         * Blank lines MAY be added to improve readability and to indicate
+         * related blocks of code except where explicitly forbidden.
+         */
 
         $foo = 'bar';
     }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This normalizes the CI matrix action and allows the codesniffer composer installer plugin.
