### PR TITLE
Prevent installation of newer `phpstan/phpdoc-parser` for now

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         "squizlabs/php_codesniffer": "^3.6",
         "webimpress/coding-standard": "^1.2"
     },
+    "conflict": {
+        "phpstan/phpdoc-parser": ">=1.6.0"
+    },
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf2a554e3b93bac1359d8ab838badba4",
+    "content-hash": "df0b677973e5a14a29eb22e02683981d",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -83,16 +83,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.7.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "367a8d9d5f7da2a0136422d27ce8840583926955"
+                "reference": "981cc368a216c988e862a75e526b6076987d1b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/367a8d9d5f7da2a0136422d27ce8840583926955",
-                "reference": "367a8d9d5f7da2a0136422d27ce8840583926955",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/981cc368a216c988e862a75e526b6076987d1b50",
+                "reference": "981cc368a216c988e862a75e526b6076987d1b50",
                 "shasum": ""
             },
             "require": {
@@ -102,7 +102,6 @@
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^1.5",
-                "phpstan/phpstan-phpunit": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
@@ -122,9 +121,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.7.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.5.1"
             },
-            "time": "2022-08-09T12:23:23+00:00"
+            "time": "2022-05-05T11:32:40+00:00"
         },
         {
             "name": "slevomat/coding-standard",


### PR DESCRIPTION
As found out in many pull requests that update `composer.lock`, `phpstan/phpdoc-parser:1.6` and
beyond are incompatible with `slevomat/coding-standard:^7`, and we should therefore restrict the
compatibility range (for now) in order to prevent downstream crashes.

This can be reverted once we upgrade to `slevomat/coding-standard:^8` (in #75)

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no
