### PR TITLE
Composer: allow for the 1.0.0 version of the Composer PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^7.4 || ^8.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
         "slevomat/coding-standard": "^7.0",
         "squizlabs/php_codesniffer": "^3.6",
         "webimpress/coding-standard": "^1.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df0b677973e5a14a29eb22e02683981d",
+    "content-hash": "933c1136fac96848396faa6f077e044b",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

The Composer PHPCS plugin has released its 1.0.0 version. :tada:

Important:
I've _widened_ the version constraints for the plugin, instead of _bumping_ it.

The reason for this is to prevent conflicts with end-user projects/other external PHPCS standards which may also require(-dev) the plugin, but may not (yet) have updated _their_ constraints for the plugin. If the version would have been bumped instead of widened, those users would get an unsolvable conflict during the `composer install` run (unless they `require-dev` the plugin for the root project, but then, that's exactly what we _don't_ want them to do as external standards managing the versions of the plugins should  be more reliable).

Ref: https://github.com/PHPCSStandards/composer-installer/releases/tag/v1.0.0
