### PR TITLE
Replace deprecated LanguageConstructSpacing sniff

### DIFF
--- a/src/LaminasCodingStandard/ruleset.xml
+++ b/src/LaminasCodingStandard/ruleset.xml
@@ -82,7 +82,7 @@
     <!-- Non executable code MUST be removed. -->
     <rule ref="Squiz.PHP.NonExecutableCode"/>
     <!-- There MUST be a single space after language constructs. -->
-    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+    <rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
     <!-- Parentheses MUST be omitted where possible. -->
     <rule ref="WebimpressCodingStandard.Formatting.RedundantParentheses"/>
     <!-- PHP function calls MUST be in lowercase. -->


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

```
> phpcs -d memory_limit=-1
WARNING: The  standard uses 1 deprecated sniff
-------------------------------------------------------------------------------------------------------------------------------------------------
-  Squiz.WhiteSpace.LanguageConstructSpacing
   This sniff has been deprecated since v3.3.0 and will be removed in v4.0.0. Use the Generic.WhiteSpace.LanguageConstructSpacing sniff instead.
```