### PR TITLE
Docs: Replace PSR-12 with PER Coding Style 3.0 with Additional Laminas Rules preserved

### DIFF
--- a/docs/book/v3/coding-style-guide.md
+++ b/docs/book/v3/coding-style-guide.md
@@ -1314,10 +1314,10 @@ public function setTitle(string $title, array $context): void
 > `@subpackage` and `@version` MUST NOT be used in comments. Git commits
 > provide accurate information.
 >
-> The words _private_, _protected_, _static_, _constructor_, _deconstructor_,
-> _Created by_, _getter_ and _setter_, MUST NOT be used in comments.
+> The words *private*, *protected*, *static*, *constructor*, *deconstructor*,
+> *Created by*, *getter* and *setter*, MUST NOT be used in comments.
 >
-> The `@var` tag MAY be used in inline comments to document the _Type_
+> The `@var` tag MAY be used in inline comments to document the *Type*
 > of properties. Single-line property comments with a `@var` tag SHOULD
 > be written as one-liners. The `@var` MAY NOT be used for constants.
 >

--- a/docs/book/v4/coding-style-guide.md
+++ b/docs/book/v4/coding-style-guide.md
@@ -1982,10 +1982,10 @@ public function setTitle(string $title, array $context): void
 > `@subpackage` and `@version` MUST NOT be used in comments. Git commits
 > provide accurate information.
 >
-> The words _private_, _protected_, _static_, _constructor_, _deconstructor_,
-> _Created by_, _getter_ and _setter_, MUST NOT be used in comments.
+> The words *private*, *protected*, *static*, *constructor*, *deconstructor*,
+> *Created by*, *getter* and *setter*, MUST NOT be used in comments.
 >
-> The `@var` tag MAY be used in inline comments to document the _Type_
+> The `@var` tag MAY be used in inline comments to document the *Type*
 > of properties. Single-line property comments with a `@var` tag SHOULD
 > be written as one-liners. The `@var` MAY NOT be used for constants.
 >

--- a/docs/book/v4/coding-style-guide.md
+++ b/docs/book/v4/coding-style-guide.md
@@ -1,19 +1,26 @@
 # Laminas Coding Style Guide
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119][].
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
+NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED",
+"MAY", and "OPTIONAL" in this document are to be interpreted as
+described in [BCP 14][] [[RFC 2119][]] [[RFC 8174][]] when, and only when, they
+appear in all capitals, as shown here.
 
-[RFC 2119]: http://tools.ietf.org/html/rfc2119
+[BCP 14]: https://datatracker.ietf.org/doc/html/bcp14/
+[RFC 2119]: https://datatracker.ietf.org/doc/html/rfc2119
+[RFC 8174]: https://datatracker.ietf.org/doc/html/rfc8174
 
 ## 1. Overview
 
-This specification extends [PSR-12][], the coding style guide and
+This specification extends [PER Coding Style][] 3.0, the evolving coding style guide and
 requires adherence to [PSR-1][], the basic coding standard.
 
-Like [PSR-12][], the intent of this specification is to reduce cognitive friction when
+Like [PER Coding Style][], the intent of this specification is to reduce cognitive friction when
 scanning code from different authors contributing to Laminas. It does so by
 enumerating a shared set of rules and expectations about how to format PHP code.
+
+For convenience, this specification includes full [PER Coding Style][] 3.0 specification
+with Additional Laminas Rules defined where applicable.
 
 ### 1.1 Previous language versions
 
@@ -26,6 +33,7 @@ This example encompasses some of the rules below as a quick overview:
 
 ```php
 <?php
+
 declare(strict_types=1);
 
 namespace Mezzio;
@@ -40,37 +48,21 @@ use Laminas\Stratigility\MiddlewarePipeInterface;
 
 use function Laminas\Stratigility\path;
 
-class Application implements MiddlewareInterface, RequestHandlerInterface
+final class Application implements MiddlewareInterface, RequestHandlerInterface
 {
-    /** @var MiddlewareFactory */
-    private $factory;
-
-    /** @var MiddlewarePipeInterface */
-    private $pipeline;
-
-    /** @var RouteCollector */
-    private $routes;
-
-    /** @var RequestHandlerRunner */
-    private $runner;
 
     public function __construct(
-        MiddlewareFactory $factory,
-        MiddlewarePipeInterface $pipeline,
-        RouteCollector $routes,
-        RequestHandlerRunner $runner
-    ) {
-        $this->factory = $factory;
-        $this->pipeline = $pipeline;
-        $this->routes = $routes;
-        $this->runner = $runner;
-    }
+        private MiddlewareFactory $factory,
+        private MiddlewarePipeInterface $pipeline,
+        private RouteCollector $routes,
+        private RequestHandlerRunner $runner,
+    ) {}
 
     /**
      * Proxies to composed pipeline to handle.
      * {@inheritDocs}
      */
-    public function handle(ServerRequestInterface $request) : ResponseInterface
+    public function handle(ServerRequestInterface $request): ResponseInterface
     {
         return $this->pipeline->handle($request);
     }
@@ -80,9 +72,20 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
      *
      * Proxies to the RequestHandlerRunner::run() method.
      */
-    public function run() : void
+    public function run(): void
     {
         $this->runner->run();
+    }
+}
+
+enum Beep: int
+{
+    case Foo = 1;
+    case Bar = 2;
+
+    public function isOdd(): bool
+    {
+        return $this->value() % 2;
     }
 }
 ```
@@ -93,7 +96,7 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
 
 Code MUST follow all rules outlined in [PSR-1].
 
-The term 'StudlyCaps' in PSR-1 MUST be interpreted as PascalCase where the first letter of
+The term "StudlyCaps" in PSR-1 MUST be interpreted as PascalCase where the first letter of
 each word is capitalized including the very first letter.
 
 > ### Additional Laminas rules
@@ -112,7 +115,7 @@ each word is capitalized including the very first letter.
 >
 > There MUST NOT be a space before a semicolon. Redundant semicolons SHOULD be avoided.
 >
-> Non executable code MUST be removed.
+> Non-executable code MUST be removed.
 >
 > There MUST be a single space after language constructs.
 >
@@ -125,7 +128,7 @@ each word is capitalized including the very first letter.
 > ### Additional Laminas rules
 >
 > There MAY NOT be any content before the opening tag. Inline HTML in PHP code
-> SHOULD be avoided. All code MUST be executable and non executable code SHOULD
+> SHOULD be avoided. All code MUST be executable and non-executable code SHOULD
 > be removed.
 >
 > The `declare(strict_types=1)` directive MUST be declared and be the first
@@ -201,48 +204,107 @@ Any new types and keywords added to future PHP versions MUST be in lower case.
 Short form of type keywords MUST be used i.e. `bool` instead of `boolean`,
 `int` instead of `integer` etc.
 
-### 2.6 Variables
+Compound types includes intersection, union, and mixed intersection and union type declarations. PHP requires
+that all compound types be structured as an ORed (unioned) series of ANDs (intersections), and that each set of
+intersections be encased with parentheses.
+
+The union symbol `|` and intersection symbol `&` MUST NOT have a leading or trailing space.  The parentheses MUST NOT
+have a leading or trailing space.
+
+If it is necessary to split a compound type into multiple lines:
+
+- If the type contains only intersections or only unions, then each line MUST have a single type.
+- If the type contains both intersections and unions, then each line MUST have a single union segment. All intersections in a segment MUST be on the same line.
+- The symbol on which the compound type is split MUST be at the start of each line.
+
+The following are correct ways to format compound types:
+
+```php
+function foo(int|string $a): User|Product
+{
+    // ...
+}
+
+function somethingWithReflection(
+    \ReflectionObject
+    |\ReflectionClass
+    |\ReflectionMethod
+    |\ReflectionParameter
+    |\ReflectionProperty $reflect
+): object|null {
+        // ...
+}
+
+function complex(array|(ArrayAccess&Traversable) $input): ArrayAccess&Traversable
+{
+    // ...
+}
+
+function veryComplex(
+    array
+    |(ArrayAccess&Traversable)
+    |(Traversable&Countable) $input): ArrayAccess&Traversable
+{
+    // ...
+}
+```
+
+If one of the ORed conditions is `null`, it MUST be the last item in the list.
+
+An intersection of a single simple type with `null` SHOULD be abbreviated using the `?` alternate syntax: `?T`.
+
+### 2.6 Trailing commas
+
+Numerous PHP constructs allow a sequence of values to be separated by a comma,
+and the final item may have an optional comma. Examples include array key/value pairs,
+function arguments, closure `use` statements, `match()` statement branches, etc.
+
+If that list is contained on a single line, then the last item MUST NOT have a trailing comma.
+
+If the list is split across multiple lines, then the last item MUST have a trailing comma.
+
+The following are examples of correct comma placement:
+
+```php
+function beep(string $a, string $b, string $c)
+{
+    // ...
+}
+
+function beep(
+    string $a,
+    string $b,
+    string $c,
+) {
+    // ...
+}
+
+$arr = ['a' => 'A', 'b' => 'B', 'c' => 'C'];
+
+$arr = [
+    'a' => 'A',
+    'b' => 'B',
+    'c' => 'C',
+];
+
+$result = match ($a) {
+    'foo' => 'Foo',
+    'bar' => 'Bar',
+    default => 'Baz',
+};
+```
+
+### 2.7 Naming
+
+This PSR RECOMMENDS following the [php-src coding standards](https://github.com/php/php-src/blob/master/CODING_STANDARDS.md#user-functionsmethods-naming-conventions) with regard to abbreviations and acronyms.
+
+Specifically:
+
+> Abbreviations and acronyms as well as initialisms SHOULD be avoided wherever possible, unless they are much more widely used than the long form (e.g. HTTP or URL). Abbreviations, acronyms, and initialisms SHOULD be treated like regular words, thus they SHOULD be written with an uppercase first character, followed by lowercase characters.
 
 > ### Additional Laminas rules
 >
 > Variable names MUST be declared in camelCase.
-
-### 2.7 Arrays
-
-> ### Additional Laminas rules
->
-> The short array syntax MUST be used to define arrays.
->
-> All values in multiline arrays must be indented with 4 spaces.
->
-> All array values must be followed by a comma, including the last value.
->
-> There MUST NOT be whitespace around the opening bracket or before the closing
-> bracket when referencing an array.
->
-> All double arrow symbols MUST be aligned to one space after the longest array
-> key.
-
-```php
-$array2 = [
-    'one'    => function () {
-        $foo    = [1, 2, 3];
-        $barBar = [
-            1,
-            2,
-            3,
-        ];
-    },
-    'longer' => 2,
-    3        => 'three',
-];
-```
-
-> The short list syntax `[...]` SHOULD be used instead of `list(...)`.
-
-```php
-[$a, $b, $c] = [1, 2, 3];
-```
 
 ## 3. Declare Statements, Namespace, and Import Statements
 
@@ -267,7 +329,7 @@ PHP.
 
 When the opening `<?php` tag is on the first line of the file, it MUST be on its
 own line with no other statements unless it is a file containing markup outside of PHP
-opening and closing tags.
+opening and closing tags.  The `<?php` tag MUST always be lower case.
 
 Import statements MUST never begin with a leading backslash as they
 must always be fully qualified.
@@ -309,6 +371,7 @@ use Vendor\Package\ClassB;
 use Vendor\Package\ClassC as C;
 use Vendor\Package\SomeNamespace\ClassD as D;
 use Vendor\Package\AnotherNamespace\ClassE as E;
+use SomeVendor\Pack\ANamespace\SubNamespace\ClassF;
 
 use function Vendor\Package\functionA;
 use function Vendor\Package\functionB;
@@ -323,13 +386,12 @@ use const Another\Vendor\CONSTANT_C;
  */
 class FooBar
 {
-    // ... additional PHP code ...
+    // ...
 }
-
 ```
 
-Compound namespaces with a depth of more than two MUST NOT be used. Therefore the
-following is the maximum compounding depth allowed:
+When using compound namespaces, there MUST NOT be more than two sub-namespaces within the group.
+That is, the following is allowed:
 
 ```php
 use Vendor\Package\SomeNamespace\{
@@ -344,6 +406,7 @@ And the following would not be allowed:
 
 ```php
 use Vendor\Package\SomeNamespace\{
+    // This has too many namespace segments to be in a group
     SubnamespaceOne\AnotherNamespace\ClassA,
     SubnamespaceOne\ClassB,
     ClassZ,
@@ -361,36 +424,61 @@ For example:
 <html>
 <body>
     <?php
-        // ... additional PHP code ...
+        // ...
     ?>
 </body>
 </html>
 ```
 
-Declare statements MUST contain no spaces and MUST be exactly `declare(strict_types=1)`
-(with an optional semi-colon terminator).
+Declare statements MUST NOT contain any spaces and MUST be exactly `declare(strict_types=1)`
+(with an optional semicolon terminator).
 
 Block declare statements are allowed and MUST be formatted as below. Note position of
 braces and spacing:
 
 ```php
 declare(ticks=1) {
-    // some code
+    // ...
 }
 ```
 
 ## 4. Classes, Properties, and Methods
 
-The term "class" refers to all classes, interfaces, and traits.
+The term "class" refers to all classes, interfaces, traits, and enums.
 
 Any closing brace MUST NOT be followed by any comment or statement on the
 same line.
 
 When instantiating a new class, parentheses MUST always be present even when
-there are no arguments passed to the constructor.
+there are no arguments passed to the constructor. For example:
 
 ```php
 new Foo();
+```
+
+If class contains no additional declarations (such as an exception that exists only to extend another exception with a new type),
+then the body of the class SHOULD be abbreviated as `{}` and placed on the same line as the previous symbol,
+separated by a space. For example:
+
+```php
+class MyException extends \RuntimeException {}
+```
+
+When accessing a class member immediately after instantiating a new class, the instantiation SHOULD NOT be wrapped in
+parentheses. For example:
+
+```php
+new Foo()->someMethod();
+new Foo()->someStaticMethod();
+new Foo()->someProperty;
+new Foo()::someStaticProperty;
+new Foo()::SOME_CONSTANT;
+```
+
+And the following SHOULD be avoided:
+
+```php
+(new Foo())->someMethod();
 ```
 
 > ### Additional Laminas rules
@@ -427,14 +515,13 @@ new Foo();
 The `extends` and `implements` keywords MUST be declared on the same line as
 the class name.
 
-The opening brace for the class MUST go on its own line; the closing brace
-for the class MUST go on the next line after the body.
+The opening brace for the class MUST go on its own line, and MUST NOT be
+preceded or followed by a blank line.
 
-Opening braces MUST be on their own line and MUST NOT be preceded or followed
-by a blank line.
+The closing brace for the class MUST go on its own line, immediately following
+the last line of the class body, and MUST NOT be preceded by a blank line.
 
-Closing braces MUST be on their own line and MUST NOT be preceded by a blank
-line.
+The following is a validly formatted class:
 
 ```php
 namespace Vendor\Package;
@@ -445,14 +532,14 @@ use OtherVendor\OtherPackage\BazClass;
 
 class ClassName extends ParentClass implements \ArrayAccess, \Countable
 {
-    // constants, properties, methods
+    // ...
 }
 ```
 
 Lists of `implements` and, in the case of interfaces, `extends` MAY be split
 across multiple lines, where each subsequent line is indented once. When doing
 so, the first item in the list MUST be on the next line, and there MUST be only
-one interface per line.
+one interface per line. For example:
 
 ```php
 namespace Vendor\Package;
@@ -466,7 +553,7 @@ class ClassName extends ParentClass implements
     \Countable,
     \Serializable
 {
-    // constants, properties, methods
+    // ...
 }
 ```
 
@@ -475,23 +562,14 @@ class ClassName extends ParentClass implements
 The `use` keyword used inside the classes to implement traits MUST be
 declared on the next line after the opening brace.
 
-```php
-namespace Vendor\Package;
-
-use Vendor\Package\FirstTrait;
-
-class ClassName
-{
-    use FirstTrait;
-}
-```
-
 Each individual trait that is imported into a class MUST be included
 one-per-line and each inclusion MUST have its own `use` import statement.
 
 > ### Additional Laminas rules
 >
 > Traits MUST be sorted alphabetically.
+
+The following is a correct example of trait usage.
 
 ```php
 namespace Vendor\Package;
@@ -510,6 +588,7 @@ class ClassName
 
 When the class has nothing after the `use` import statement, the class
 closing brace MUST be on the next line after the `use` import statement.
+For example:
 
 ```php
 namespace Vendor\Package;
@@ -522,7 +601,7 @@ class ClassName
 }
 ```
 
-Otherwise, it MUST have a blank line after the `use` import statement.
+Otherwise, it MUST have a blank line after the `use` import statement, as in:
 
 ```php
 namespace Vendor\Package;
@@ -537,15 +616,18 @@ class ClassName
 }
 ```
 
-When using the `insteadof` and `as` operators they must be used as follows taking
+When using the `insteadof` and `as` operators they MUST be used as follows taking
 note of indentation, spacing, and new lines.
 
 ```php
 class Talker
 {
-    use A, B, C {
-        B::smallTalk insteadof A;
-        A::bigTalk insteadof C;
+    use A;
+    use B {
+        A::smallTalk insteadof B;
+    }
+    use C {
+        B::bigTalk insteadof C;
         C::mediumTalk as FooBar;
     }
 }
@@ -553,16 +635,15 @@ class Talker
 
 ### 4.3 Properties and Constants
 
-Visibility MUST be declared on all properties.
+Visibility MUST be declared on all properties.  If set-visibility is specified, then the general visibility MAY be omitted.
 
-Visibility MUST be declared on all constants if your project PHP minimum
-version supports constant visibilities (PHP 7.1 or later).
+Visibility MUST be declared on all constants.
 
 The `var` keyword MUST NOT be used to declare a property.
 
-There MUST NOT be more than one property declared per statement.
+There MUST NOT be more than one property or constant declared per statement.
 
-Property names MUST NOT be prefixed with a single underscore to indicate
+Property or constant names MUST NOT be prefixed with a single underscore to indicate
 protected or private visibility. That is, an underscore prefix explicitly has
 no meaning.
 
@@ -590,8 +671,8 @@ Method names MUST NOT be prefixed with a single underscore to indicate
 protected or private visibility. That is, an underscore prefix explicitly has
 no meaning.
 
-Method and function names MUST NOT be declared with space after the method name.
-The opening brace MUST go on its own line, and the closing brace MUST go on the
+Method and function names MUST NOT be declared with space after the method name. The
+opening brace MUST go on its own line, and the closing brace MUST go on the
 next line following the body. There MUST NOT be a space after the opening
 parenthesis, and there MUST NOT be a space before the closing parenthesis.
 
@@ -613,7 +694,7 @@ class ClassName
 {
     public function fooBarBaz($arg1, &$arg2, $arg3 = [])
     {
-        // method body
+        // ...
     }
 }
 ```
@@ -624,24 +705,47 @@ parentheses, commas, spaces, and braces:
 ```php
 function fooBarBaz($arg1, &$arg2, $arg3 = [])
 {
-    // function body
+    // ...
 }
 ```
 
-### 4.5 Method and Function Arguments
+If a function or method contains no statements or comments (such as an empty no-op implementation or when using
+constructor property promotion), then the body SHOULD be abbreviated as `{}` and placed on the same
+line as the previous symbol, separated by a space. For example:
+
+```php
+class Point
+{
+    public function __construct(private int $x, private int $y) {}
+    
+    // ...
+}
+```
+
+```php
+class Point
+{
+    public function __construct(
+      public readonly int $x,
+      public readonly int $y,
+    ) {}
+}
+```
+
+### 4.5 Method and Function Parameters
 
 In the argument list, there MUST NOT be a space before each comma, and there
 MUST be one space after each comma.
 
-Method and function arguments with default values MUST go at the end of the argument
-list.
+Method and function parameters with default values MUST go at the end of the argument
+list. For example:
 
 ```php
 class ClassName
 {
     public function foo(int $arg1, &$arg2, $arg3 = [])
     {
-        // method body
+        // ...
     }
 }
 ```
@@ -652,7 +756,7 @@ next line, and there MUST be only one argument per line.
 
 When the argument list is split across multiple lines, the closing parenthesis
 and opening brace MUST be placed together on their own line with one space
-between them.
+between them. For example:
 
 ```php
 class ClassName
@@ -660,9 +764,9 @@ class ClassName
     public function aVeryLongMethodName(
         ClassTypeHint $arg1,
         &$arg2,
-        array $arg3 = []
+        array $arg3 = [],
     ) {
-        // method body
+        // ...
     }
 }
 ```
@@ -670,7 +774,7 @@ class ClassName
 When you have a return type declaration present, there MUST be one space after
 the colon followed by the type declaration. The colon and declaration MUST be
 on the same line as the argument list closing parenthesis with no spaces between
-the two characters.
+the two characters. For example:
 
 ```php
 class ReturnTypeVariations
@@ -683,7 +787,7 @@ class ReturnTypeVariations
     public function anotherFunction(
         string $foo,
         string $bar,
-        int $baz
+        int $baz,
     ): string {
         return 'foo';
     }
@@ -691,21 +795,21 @@ class ReturnTypeVariations
 ```
 
 In nullable type declarations, there MUST NOT be a space between the question mark
-and the type.
-
-> ### Additional Laminas rules
->
-> The question mark MUST be used when the default argument value is null.
+and the type. For example:
 
 ```php
 class ReturnTypeVariations
 {
-    public function functionName(?string $arg1, ?int &$arg2 = null): ?string
+    public function functionName(?string $arg1, ?int &$arg2): ?string
     {
         return 'foo';
     }
 }
 ```
+
+> ### Additional Laminas rules
+>
+> The question mark MUST be used when the default argument value is null.
 
 When using the reference operator `&` before an argument, there MUST NOT be
 a space after it, like in the previous example.
@@ -716,7 +820,7 @@ name:
 ```php
 public function process(string $algorithm, ...$parts)
 {
-    // processing
+    // ...
 }
 ```
 
@@ -726,33 +830,49 @@ there MUST NOT be any space between the two of them:
 ```php
 public function process(string $algorithm, &...$parts)
 {
-    // processing
+    // ...
 }
 ```
 
-### 4.6 `abstract`, `final`, and `static`
+### 4.6 Modifier Keywords
 
-When present, the `abstract` and `final` declarations MUST precede the
-visibility declaration.
+Classes, properties, and methods have numerous keyword modifiers that alter how the
+engine and language handles them. When present, they MUST be in the following order:
 
-> ### Additional Laminas rules
->
-> The `final` keyword on methods MUST be omitted in final declared classes.
+- Inheritance modifier: `abstract` or `final`
+- Visibility modifier: `public`, `protected`, or `private`
+- Set-visibility modifier: `public(set)`, `protected(set)`, or `private(set)`
+- Scope modifier: `static`
+- Mutation modifier: `readonly`
+- Type declaration
+- Name
 
-When present, the `static` declaration MUST come after the visibility
-declaration.
+All keywords MUST be on a single line, and MUST be separated by a single space.  All keywords MUST be all lower-case.  The `public` keyword MAY be omitted when using a set-visibility on a public-read property.
+
+The following is a correct example of modifier keyword usage:
 
 ```php
 abstract class ClassName
 {
-    protected static $foo;
+    protected static string $foo;
+
+    private readonly int $beep;
+
+    protected private(set) string $name;
+
+    protected(set) string $boop;
 
     abstract protected function zim();
 
     final public static function bar()
     {
-        // method body
+        // ...
     }
+}
+
+readonly class ValueObject
+{
+    // ...
 }
 ```
 
@@ -764,6 +884,8 @@ after the opening parenthesis, and there MUST NOT be a space before the
 closing parenthesis. In the argument list, there MUST NOT be a space before
 each comma, and there MUST be one space after each comma.
 
+The following lines show correct calls:
+
 ```php
 bar();
 $foo->bar($arg1);
@@ -773,14 +895,16 @@ Foo::bar($arg2, $arg3);
 Argument lists MAY be split across multiple lines, where each subsequent line
 is indented once. When doing so, the first item in the list MUST be on the
 next line, and there MUST be only one argument per line. A single argument being
-split across multiple lines (as might be the case with an anonymous function or
+split across multiple lines (as might be the case with a closure or
 array) does not constitute splitting the argument list itself.
+
+The following examples show correct argument usage.
 
 ```php
 $foo->bar(
     $longArgument,
     $longerArgument,
-    $muchLongerArgument
+    $muchLongerArgument,
 );
 ```
 
@@ -792,6 +916,208 @@ somefunction($foo, $bar, [
 $app->get('/hello/{name}', function ($name) use ($app) {
     return 'Hello ' . $app->escape($name);
 });
+```
+
+If using named arguments, there MUST NOT be a space between the argument name
+and colon, and there MUST be a single space between the colon and the argument value. For example:
+
+```php
+somefunction($a, b: $b, c: 'c');
+```
+
+Method chaining MAY be put on separate lines, where each subsequent line is indented once. When doing so, the first
+method MUST be on the next line. For example:
+
+```php
+$someInstance
+    ->create()
+    ->prepare()
+    ->run();
+```
+
+The `exit()` and `die()` functions SHOULD always be called with parentheses even if no argument is given to clearly
+distinguish them from an access to a constant named `exit` or `die`. For example:
+
+```php
+exit();
+exit(1);
+exit("Success!");
+die();
+
+$result = foo() ?? exit();
+```
+
+### 4.8 Function Callable References
+
+A function or method may be referenced in a way that creates a closure out of it, by providing `...` in place of arguments.
+
+If so, the `...` MUST NOT include any whitespace before or after. That is, the correct format is `foo(...)`.
+
+### 4.9 Property Hooks
+
+Object properties may also include hooks, which have a number of syntactic options.
+
+When using the long form of hooks:
+
+- The opening brace MUST be on the same line as the property.
+- The opening brace MUST be separated from the property name or its default value by a single space.
+- The closing brace MUST be on its own line, and have no comment following it.
+- The entire body of the hook definition MUST be indented one level.
+- The body of each hook MUST be indented one level.
+- If multiple hooks are declared, they MUST be separated by at least a single line break.  They
+  MAY be separated by an additional blank line to aid readability.
+
+For example:
+
+```php
+class Example
+{
+    public string $newName = 'Me' {
+        set(string $value) {
+            if (strlen($value) < 3) {
+                throw new \Exception('Too short');
+            }
+            $this->newName = ucfirst($value);
+        }
+    }
+
+    public string $department {
+        get {
+            return $this->values[__PROPERTY__];
+        }
+        set {
+            $this->values[__PROPERTY__] = $value;
+        }
+    }
+    // or
+    public string $department {
+        get {
+            return $this->values[__PROPERTY__];
+        }
+
+        set {
+            $this->values[__PROPERTY__] = $value;
+        }
+    }
+}
+```
+
+Property hooks also support multiple short-hook variations.
+
+For a `set` hook, if the argument name and type do not need to be redefined, then they MAY be omitted.
+
+If a hook consists of a single expression, then PHP allows it to be shortened using `=>`.  In that case:
+
+- There MUST be a single space on either side of the `=>` symbol.
+- The body MUST begin on the same line as the hook name and `=>`.
+- Wrapping is allowed if the expression used allows for wrapping, using the rules defined elsewhere in this document.
+
+```php
+class Example
+{
+    public string $myName {
+        get => __CLASS__;
+    }
+
+    public string $newName {
+        set => ucfirst($value);
+    }
+}
+```
+
+Additionally, if the following criteria are met:
+
+- There is only one hook implementation.
+- That hook uses the short-hook syntax.
+- That hook expression does not contain any wrapping.
+
+Then the hook MAY be listed entirely inline.  In that case,
+
+- The hook name MUST be separated from the opening brace and the arrow operator by a single space
+- The semicolon ending of the hook MUST be separated from the closing brace by a single space.
+
+For example:
+
+```php
+class Example
+{
+    public string $myName { get => __CLASS__; }
+
+    public string $newName { set => ucfirst($value); }
+}
+```
+
+Property hooks MAY also be defined in constructor-promoted properties.  However, they
+MUST be only a single hook, with a short-syntax body, defined on a single line as above.
+If those criteria are not met, then the promoted property MUST NOT have any hooks defined
+inline.
+
+```php
+class Example
+{
+    public function __construct(
+        public string $name { set => ucfirst($value); }
+    ) {}
+}
+```
+
+The following is ***not allowed*** due to the hook being too complex:
+
+```php
+class Example
+{
+    public function __construct(
+        public string $name {
+            set {
+                if (strlen($value) < 3) {
+                    throw new \Exception('Too short');
+                }
+                $this->newName = ucfirst($value);
+            }
+        }
+    ) {}
+}
+```
+
+## 4.10 Interface and abstract properties
+
+Abstract properties may be defined in interfaces or abstract classes, but are required to
+specify if they must support `get` operations, `set` operations, or both.  In the case
+of abstract classes, they MAY include a body for one or another hook.
+
+If there is a body for any hook, then the entire hook block MUST follow
+the same rules as for defined hooks above.  The only difference is that
+a hook that has no body specified have a single semicolon after the hook
+keyword, with no space before it.
+
+```php
+abstract class Example {
+    abstract public string $name {
+        get => ucfirst($this->name);
+        set;
+    }
+}
+```
+
+If there is no body for either hook, then the following rules apply:
+
+- The operation block MUST be on the same line as the property.
+- There MUST be a single space between the property name and the operation block `{}`.
+- There MUST be a single space after the opening `{`.
+- There MUST be a single space before the closing `}`;
+- There MUST NOT be a space between the operation and its required semicolon.
+- If multiple operations are specified, they MUST be separated by a single space.
+- The `get` operation MUST be listed before the `set` operation.
+
+```php
+interface Example
+{
+    public string $readable { get; }
+
+    public string $writeable { set; }
+
+    public string $both { get; set; }
+}
 ```
 
 ## 5. Control Structures
@@ -826,11 +1152,11 @@ closing brace from the earlier body.
 
 ```php
 if ($expr1) {
-    // if body
+    // ...
 } elseif ($expr2) {
-    // elseif body
+    // ...
 } else {
-    // else body;
+    // ...
 }
 ```
 
@@ -841,24 +1167,23 @@ Expressions in parentheses MAY be split across multiple lines, where each
 subsequent line is indented at least once. When doing so, the first condition
 MUST be on the next line. The closing parenthesis and opening brace MUST be
 placed together on their own line with one space between them. Boolean
-operators between conditions MUST always be at the beginning or at the end of
-the line, not a mix of both.
+operators between conditions MUST always be at the beginning. For example:
 
 ```php
 if (
     $expr1
     && $expr2
 ) {
-    // if body
+    // ...
 } elseif (
     $expr3
     && $expr4
 ) {
-    // elseif body
+    // ...
 }
 ```
 
-### 5.2 `switch`, `case`
+### 5.2 `switch`, `case`, `match`
 
 A `switch` structure looks like the following. Note the placement of
 parentheses, spaces, and braces. The `case` statement MUST be indented once
@@ -894,16 +1219,28 @@ Expressions in parentheses MAY be split across multiple lines, where each
 subsequent line is indented at least once. When doing so, the first condition
 MUST be on the next line. The closing parenthesis and opening brace MUST be
 placed together on their own line with one space between them. Boolean
-operators between conditions MUST always be at the beginning or at the end of
-the line, not a mix of both.
+operators between conditions MUST always be at the beginning. For example:
 
 ```php
+<?php
+
 switch (
     $expr1
     && $expr2
 ) {
-    // structure body
+    // ...
 }
+```
+
+Similarly, a `match` expression looks like the following. Note the placement
+of parentheses, spaces, and braces.
+
+```php
+$returnValue = match ($expr) {
+    0 => 'First case',
+    1, 2, 3 => multipleCases(),
+    default => 'Default case',
+};
 ```
 
 ### 5.3 `while`, `do while`
@@ -913,7 +1250,7 @@ parentheses, spaces, and braces.
 
 ```php
 while ($expr) {
-    // structure body
+    // ...
 }
 ```
 
@@ -921,15 +1258,14 @@ Expressions in parentheses MAY be split across multiple lines, where each
 subsequent line is indented at least once. When doing so, the first condition
 MUST be on the next line. The closing parenthesis and opening brace MUST be
 placed together on their own line with one space between them. Boolean
-operators between conditions MUST always be at the beginning or at the end of
-the line, not a mix of both.
+operators between conditions MUST always be at the beginning.
 
 ```php
 while (
     $expr1
     && $expr2
 ) {
-    // structure body
+    // ...
 }
 ```
 
@@ -938,18 +1274,18 @@ of parentheses, spaces, and braces.
 
 ```php
 do {
-    // structure body;
+    // ...
 } while ($expr);
 ```
 
 Expressions in parentheses MAY be split across multiple lines, where each
 subsequent line is indented at least once. When doing so, the first condition
 MUST be on the next line. Boolean operators between conditions MUST
-always be at the beginning or at the end of the line, not a mix of both.
+always be at the beginning. For example:
 
 ```php
 do {
-    // structure body;
+    // ...
 } while (
     $expr1
     && $expr2
@@ -963,14 +1299,14 @@ spaces, and braces.
 
 ```php
 for ($i = 0; $i < 10; $i++) {
-    // for body
+    // ...
 }
 ```
 
 Expressions in parentheses MAY be split across multiple lines, where each
 subsequent line is indented at least once. When doing so, the first expression
 MUST be on the next line. The closing parenthesis and opening brace MUST be
-placed together on their own line with one space between them.
+placed together on their own line with one space between them. For example:
 
 ```php
 for (
@@ -978,7 +1314,7 @@ for (
     $i < 10;
     $i++
 ) {
-    // for body
+    // ...
 }
 ```
 
@@ -989,7 +1325,7 @@ parentheses, spaces, and braces.
 
 ```php
 foreach ($iterable as $key => $value) {
-    // foreach body
+    // ...
 }
 ```
 
@@ -1000,13 +1336,13 @@ parentheses, spaces, and braces.
 
 ```php
 try {
-    // try body
+    // ...
 } catch (FirstThrowableType $e) {
-    // catch body
-} catch (OtherThrowableType | AnotherThrowableType $e) {
-    // catch body
+    // ...
+} catch (OtherThrowableType|AnotherThrowableType $e) {
+    // ...
 } finally {
-    // finally body
+    // ...
 }
 ```
 
@@ -1016,8 +1352,7 @@ try {
 
 ## 6. Operators
 
-Style rules for operators are grouped by arity (the number of operands they
-take).
+Style rules for operators are grouped by arity (the number of operands they take).
 
 When space is permitted around an operator, multiple spaces MAY be
 used for readability purposes.
@@ -1046,18 +1381,15 @@ All operators not described here are left undefined.
 ### 6.1. Unary operators
 
 The increment/decrement operators MUST NOT have any space between
-the operator and operand.
+the operator and operand:
 
 ```php
 $i++;
 ++$j;
 ```
 
-Type casting operators MUST NOT have any space within the parentheses.
-
-> ### Additional Laminas rules
->
-> There MUST be one whitespace after a type casting operator.
+Type casting operators MUST NOT have any space within the parentheses and MUST be separated from the variable they are
+operating on by exactly one space:
 
 ```php
 $intValue = (int) $input;
@@ -1104,10 +1436,32 @@ MUST follow the same style rules as other binary [comparison][] operators:
 $variable = $foo ?: 'bar';
 ```
 
+### 6.4. Operator's placement
+
+A statement that includes an operator MAY be split across multiple lines, where
+each subsequent line is indented once. When doing so, the operator MUST be
+placed at the beginning of the new line; ternaries MUST occupy 3 lines, never 2.
+
+For example:
+
+```php
+<?php
+
+$variable1 = $ternaryOperatorExpr
+    ? 'fizz'
+    : 'buzz';
+
+$variable2 = $possibleNullableExpr
+    ?? 'fallback';
+
+$variable3 = $elvisExpr
+    ?: 'qix';
+```
+
 ## 7. Closures
 
-Closures MUST be declared with a space after the `function` keyword, and a
-space before and after the `use` keyword.
+Closures, also known as anonymous functions, MUST be declared with a space
+after the `function` keyword, and a space before and after the `use` keyword.
 
 The opening brace MUST go on the same line, and the closing brace MUST go on
 the next line following the body.
@@ -1135,15 +1489,15 @@ parentheses, commas, spaces, and braces:
 
 ```php
 $closureWithArgs = function ($arg1, $arg2) {
-    // body
+    // ...
 };
 
 $closureWithArgsAndVars = function ($arg1, $arg2) use ($var1, $var2) {
-    // body
+    // ...
 };
 
 $closureWithArgsVarsAndReturn = function ($arg1, $arg2) use ($var1, $var2): bool {
-    // body
+    // ...
 };
 ```
 
@@ -1163,45 +1517,45 @@ variable lists split across multiple lines.
 $longArgs_noVars = function (
     $longArgument,
     $longerArgument,
-    $muchLongerArgument
+    $muchLongerArgument,
 ) {
-   // body
+   // ...
 };
 
 $noArgs_longVars = function () use (
     $longVar1,
     $longerVar2,
-    $muchLongerVar3
+    $muchLongerVar3,
 ) {
-   // body
+   // ...
 };
 
 $longArgs_longVars = function (
     $longArgument,
     $longerArgument,
-    $muchLongerArgument
+    $muchLongerArgument,
 ) use (
     $longVar1,
     $longerVar2,
-    $muchLongerVar3
+    $muchLongerVar3,
 ) {
-   // body
+   // ...
 };
 
 $longArgs_shortVars = function (
     $longArgument,
     $longerArgument,
-    $muchLongerArgument
+    $muchLongerArgument,
 ) use ($var1) {
-   // body
+   // ...
 };
 
 $shortArgs_longVars = function ($arg) use (
     $longVar1,
     $longerVar2,
-    $muchLongerVar3
+    $muchLongerVar3,
 ) {
-   // body
+   // ...
 };
 ```
 
@@ -1212,10 +1566,41 @@ in a function or method call as an argument.
 $foo->bar(
     $arg1,
     function ($arg2) use ($var1) {
-        // body
+        // ...
     },
-    $arg3
+    $arg3,
 );
+```
+
+### 7.1 Short Closures
+
+Short closures, also known as arrow functions, MUST follow the same guidelines
+and principles as long closures above, with the following additions.
+
+The `fn` keyword MUST NOT be succeeded by a space.
+
+The `=>` symbol MUST be preceded and succeeded by a space.
+
+The semicolon at the end of the expression MUST NOT be preceded by a space.
+
+The expression portion MAY be split to a subsequent line. If so, the `=>` MUST be included
+on the second line, and MUST be indented once.
+
+The following examples show proper common usage of short closures.
+
+```php
+$func = fn(int $x, int $y): int => $x + $y;
+
+$func = fn(int $x, int $y): int
+    => $x + $y;
+
+$func = fn(
+    int $x,
+    int $y,
+): int
+    => $x + $y;
+
+$result = $collection->reduce(fn(int $x, int $y): int => $x + $y, 0);
 ```
 
 ## 8. Anonymous Classes
@@ -1232,23 +1617,306 @@ the list of `implements` interfaces does not wrap. If the list of interfaces
 wraps, the brace MUST be placed on the line immediately following the last
 interface.
 
+If the anonymous class has no arguments, the `()` after `class` MUST be omitted. For example:
+
 ```php
 // Brace on the same line
+// No arguments
 $instance = new class extends \Foo implements \HandleableInterface {
-    // Class content
+    // ...
 };
 
 // Brace on the next line
-$instance = new class extends \Foo implements
+// Constructor arguments
+$instance = new class ($a) extends \Foo implements
     \ArrayAccess,
     \Countable,
     \Serializable
 {
-    // Class content
+    public function __construct(public int $a)
+    {
+    }
+    // ...
 };
 ```
 
-## 9. Commenting and DocBlocks
+## 9. Enumerations
+
+Enumerations (enums) MUST follow the same guidelines as classes, except where otherwise noted below.
+
+Methods in enums MUST follow the same guidelines as methods in classes. Non-public methods MUST use `private`
+instead of `protected`, as enums do not support inheritance.
+
+When using a backed enum, there MUST NOT be a space between the enum name and colon, and there MUST be exactly one
+space between the colon and the backing type. This is consistent with the style for return types.
+
+Enum case declarations MUST use PascalCase capitalization. Enum case declarations MUST be on their own line.
+
+Constants in Enumerations MAY use either PascalCase or UPPER_CASE capitalization. PascalCase is RECOMMENDED,
+so that it is consistent with case declarations.
+
+The following example shows a typical valid Enum:
+
+```php
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Spades = 'S';
+    case Clubs = 'C';
+
+    public const Wild = self::Spades;
+}
+```
+
+## 10. Heredoc and Nowdoc
+
+A nowdoc SHOULD be used wherever possible. Heredoc MAY be used when a nowdoc
+does not satisfy requirements.
+
+Heredoc and nowdoc syntax is largely governed by PHP requirements with the only
+allowed variation being indentation. Declared heredocs or nowdocs MUST
+begin on the same line as the context the declaration is being used in.
+Subsequent lines in the heredoc or nowdoc MUST be indented once past the scope
+indentation they are declared in.
+
+The following is ***not allowed*** due to the heredoc beginning on a
+different line than the context it's being declared in:
+
+```php
+$notAllowed =
+<<<'COUNTEREXAMPLE'
+    This
+    is
+    not
+    allowed.
+    COUNTEREXAMPLE;
+```
+
+Instead, the heredoc MUST be declared on the same line as the variable
+declaration it's being set against.
+
+The following is ***not allowed*** due to the scope indention not matching the scope the
+heredoc is declared in:
+
+```php
+function notAllowed()
+{
+    $notAllowed = <<<'COUNTEREXAMPLE'
+This
+is
+not
+allowed.
+COUNTEREXAMPLE;
+}
+```
+
+Instead, the heredoc MUST be indented once past the indentation of the scope
+it's declared in.
+
+The following is an example of both heredocs and nowdocs declared in a
+compliant way:
+
+```php
+function allowed()
+{
+    $allowedHeredoc = <<<COMPLIANT
+        This
+        is
+        a
+        compliant
+        heredoc
+        COMPLIANT;
+
+    $allowedNowdoc = <<<'COMPLIANT'
+        This
+        is
+        a
+        compliant
+        nowdoc
+        COMPLIANT;
+
+    var_dump(
+        'foo',
+        <<<'COMPLIANT'
+            This
+            is
+            a
+            compliant
+            parameter
+            COMPLIANT,
+        'bar',
+    );
+}
+```
+
+## 11. Arrays
+
+Arrays MUST be declared using the short array syntax.
+
+```php
+$arr = [];
+```
+
+Arrays MUST follow the trailing comma guidelines.
+
+Array declarations MAY be split across multiple lines, where each subsequent line
+is indented once. When doing so, the first value in the array MUST be on the
+next line, and there MUST be only one value per line.
+
+When the array declaration is split across multiple lines, the opening bracket
+MUST be placed on the same line as the equals sign. The closing bracket
+MUST be placed on the next line after the last value. There MUST NOT be more
+than one value assignment per line. Value assignments MAY use a single line
+or multiple lines.
+
+The following example shows correct array usage:
+
+```php
+<?php
+
+$arr1 = ['single', 'line', 'declaration'];
+
+$arr2 = [
+    'multi',
+    'line',
+    'declaration',
+    ['values' => 1, 5, 7],
+    [
+        'nested',
+        'array',
+    ],
+];
+```
+
+> ### Additional Laminas rules
+>
+> There MUST NOT be whitespace around the opening bracket or before the closing
+> bracket when referencing an array.
+>
+> All double arrow symbols MUST be aligned to one space after the longest array
+> key.
+
+```php
+$array2 = [
+    'one'    => function () {
+        $foo    = [1, 2, 3];
+        $barBar = [
+            1,
+            2,
+            3,
+        ];
+    },
+    'longer' => 2,
+    3        => 'three',
+];
+```
+
+> The short list syntax `[...]` SHOULD be used instead of `list(...)`.
+
+```php
+[$a, $b, $c] = [1, 2, 3];
+```
+
+## 12. Attributes
+
+### 12.1 Basics
+
+Attribute names MUST immediately follow the opening attribute block indicator `#[` with no space.
+
+If an attribute has no arguments, the `()` MUST be omitted.
+
+The closing attribute block indicator `]` MUST follow the last character of the attribute name or the closing `)` of
+its argument list, with no preceding space.
+
+The construct `#[...]` is referred to as an "attribute block" in this document.
+
+### 12.2 Placement
+
+Attributes on classes, methods, functions, constants and properties MUST
+be placed on their own line, immediately prior to the structure being described.
+
+For attributes on parameters, if the parameter list is presented on a single line,
+the attribute MUST be placed inline with the parameter it describes, separated by a single space.
+If the parameter list is split into multiple lines for any reason, the attribute MUST be placed on
+its own line prior to the parameter, indented the same as the parameter. If the parameter list
+is split into multiple lines, a blank line MAY be included between one parameter and the attributes
+of the following parameter in order to aid readability.
+
+If a comment docblock is present on a structure that also includes an attribute, the comment block MUST
+come first, followed by any attributes, followed by the structure itself. There MUST NOT be any blank lines
+between the docblock and attributes, or the attributes and the structure.
+
+If two separate attribute blocks are used in a multi-line context, they MUST be on separate lines with no blank
+lines between them.
+
+### 12.3 Compound attributes
+
+If multiple attributes are placed in the same attribute block, they MUST be separated by a comma with a space
+following but no space preceding. If the attribute list is split into multiple lines for any reason, then the
+attributes MUST be placed in separate attribute blocks. Those blocks may themselves contain multiple
+attributes provided this rule is respected.
+
+If an attribute's argument list is split into multiple lines for any reason, then:
+
+- The attribute MUST be the only one in its attribute block.
+- The attribute arguments MUST follow the same rules as defined for multiline function calls.
+
+### 12.4 Example
+
+The following is an example of valid attribute usage.
+
+```php
+#[Foo]
+#[Bar('baz')]
+class Demo
+{
+    #[Beep]
+    private Foo $foo;
+
+    public function __construct(
+        #[Load(context: 'foo', bar: true)]
+        private readonly FooService $fooService,
+
+        #[LoadProxy(context: 'bar')]
+        private readonly BarService $barService,
+    ) {}
+
+    /**
+     * Sets the foo.
+     */
+    #[Poink('narf'), Narf('poink')]
+    public function setFoo(#[Beep] Foo $new): void
+    {
+        // ...
+    }
+
+    #[Complex(
+        prop: 'val',
+        other: 5,
+    )]
+    #[Other, Stuff]
+    #[Here]
+    public function complicated(
+        string $a,
+
+        #[Decl]
+        string $b,
+
+        #[Complex(
+            prop: 'val',
+            other: 5,
+        )]
+        string $c,
+
+        int $d,
+    ): string {
+        // ...
+    }
+}
+```
+
+## 13. Commenting and DocBlocks
 
 > ### Additional Laminas rules
 >
@@ -1326,28 +1994,26 @@ public function setTitle(string $title, array $context): void
 > Inline DocComments MAY be used at the end of the line, with at least a
 > single space preceding. Inline DocComments MUST NOT be placed after curly
 > brackets.
->
-> Heredoc and nowdoc tags MUST be uppercase without spaces.
 
 [PSR-1]: https://www.php-fig.org/psr/psr-1/
-[PSR-12]: https://www.php-fig.org/psr/psr-12/
-[keywords]: https://www.php.net/manual/reserved.keywords.php
-[types]: https://www.php.net/manual/reserved.other-reserved-words.php
-[arithmetic]: https://www.php.net/manual/language.operators.arithmetic.php
-[assignment]: https://www.php.net/manual/language.operators.assignment.php
-[comparison]: https://www.php.net/manual/language.operators.comparison.php
-[bitwise]: https://www.php.net/manual/language.operators.bitwise.php
-[logical]: https://www.php.net/manual/language.operators.logical.php
-[string]: https://www.php.net/manual/language.operators.string.php
-[type]: https://www.php.net/manual/language.operators.type.php
-[short open tag]: https://www.php.net/manual/language.basic-syntax.phptags.php
-[70.deprecated]: https://www.php.net/manual/migration70.deprecated.php
-[71.deprecated]: https://www.php.net/manual/migration71.deprecated.php
-[72.deprecated]: https://www.php.net/manual/migration72.deprecated.php
-[73.deprecated]: https://www.php.net/manual/migration73.deprecated.php
-[74.deprecated]: https://www.php.net/manual/migration74.deprecated.php
-[backtick operator]: https://www.php.net/manual/language.operators.execution.php
-[goto]: https://www.php.net/manual/control-structures.goto.php
-[global]: https://www.php.net/manual/language.variables.scope.php#language.variables.scope.global
-[PHP_SAPI]: https://www.php.net/manual/function.php-sapi-name.php#refsect1-function.php-sapi-name-notes
-[aliases]: https://www.php.net/manual/aliases.php
+[PER Coding Style]: https://www.php-fig.org/per/coding-style/
+[keywords]: https://php.net/manual/en/reserved.keywords.php
+[types]: https://php.net/manual/en/reserved.other-reserved-words.php
+[arithmetic]: https://php.net/manual/en/language.operators.arithmetic.php
+[assignment]: https://php.net/manual/en/language.operators.assignment.php
+[comparison]: https://php.net/manual/en/language.operators.comparison.php
+[bitwise]: https://php.net/manual/en/language.operators.bitwise.php
+[logical]: https://php.net/manual/en/language.operators.logical.php
+[string]: https://php.net/manual/en/language.operators.string.php
+[type]: https://php.net/manual/en/language.operators.type.php
+[short open tag]: https://php.net/manual/en/language.basic-syntax.phptags.php
+[70.deprecated]: https://php.net/manual/en/migration70.deprecated.php
+[71.deprecated]: https://php.net/manual/en/migration71.deprecated.php
+[72.deprecated]: https://php.net/manual/en/migration72.deprecated.php
+[73.deprecated]: https://php.net/manual/en/migration73.deprecated.php
+[74.deprecated]: https://php.net/manual/en/migration74.deprecated.php
+[backtick operator]: https://php.net/manual/en/language.operators.execution.php
+[goto]: https://php.net/manual/en/control-structures.goto.php
+[global]: https://php.net/manual/en/language.variables.scope.php#language.variables.scope.global
+[PHP_SAPI]: https://php.net/manual/en/function.php-sapi-name.php#refsect1-function.php-sapi-name-notes
+[aliases]: https://php.net/manual/en/aliases.php

--- a/docs/book/v4/intro.md
+++ b/docs/book/v4/intro.md
@@ -1,7 +1,7 @@
 # Introduction
 
-**This specification extends and expands [PSR-12](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md),
-the extended coding style guide and requires adherence to [PSR-1](https://www.php-fig.org/psr/psr-1),
+**This specification extends and expands [PER Coding Style](https://www.php-fig.org/per/coding-style/),
+the evolving coding style guide and requires adherence to [PSR-1](https://www.php-fig.org/psr/psr-1),
 the basic coding standard.**
 
 These are minimal specifications and don't address all factors, including things like:
@@ -82,8 +82,8 @@ the ["Annotated Ruleset" of PHP_CodeSniffer](https://github.com/PHPCSStandards/P
 > ### Deprecation
 >
 > Before PHP_CodeSniffer version 3.2.0, `// @codingStandardsIgnoreStart` and
-> `// @codingStandardsIgnoreEnd` were used. These are deprecated and will be
-> removed in PHP_CodeSniffer version 4.0.
+> `// @codingStandardsIgnoreEnd` were used. These were removed in
+> PHP_CodeSniffer version 4.0.
 
 Disable parts of a file:
 
@@ -111,8 +111,8 @@ $xmlPackage->send();
 > ### New Rules or Sniffs
 >
 > New rules or Sniffs may not be introduced in minor or bugfix releases and
-> should always be based on the develop branch and queued for the next major
-> release, unless considered a bugfix for existing rules.
+> should always be based on the next major release branch, unless considered a
+> bugfix for existing rules.
 
 If you want to test changes against Laminas components or your own projects, install your forked
 laminas-coding-standard globally with Composer:


### PR DESCRIPTION
PER Coding Style is an evolving coding style that is NOT an extension to PSR-12 but rather it can be seen as an evolution with the same goals but aiming to keep up with PHP changes and features.

As it stands, version 3.0 It is mostly compatible with our current coding standard sans may be some conflicting cases with existing implementation around new PHP features and new rules that we did not previously enforced one way or another.


